### PR TITLE
Small fixes

### DIFF
--- a/code/html/index.html
+++ b/code/html/index.html
@@ -150,7 +150,7 @@ export const QUERY = gql`
 export const Loading = () => &lt;div&gt;Loading users...&lt;/div&gt;
 export const Empty = () => &lt;div&gt;No users yet!&lt;/div&gt;
 export const Failure = ({ message }) => &lt;div&gt;Error: {message}&lt;/div&gt;
-export const Success = ({ users }) {
+export const Success = ({ users }) => {
   return (
     &lt;ul&gt;
       { users.map(user => (

--- a/code/html/layouts/application.html
+++ b/code/html/layouts/application.html
@@ -26,7 +26,7 @@
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
   </head>
 
-  <body class="relative bg-white text-gray-900 font-sans antialiased h-full flex flex-col" data-controller="application" data-action="keyup->application#focusSearch">
+  <body class="relative bg-white text-gray-900 font-sans antialiased h-full flex flex-col" data-controller="application" data-action="keydown@window->application#focusSearch">
     <div class="flex-grow flex-shrink-0 flex-auto">
       <section class="bg-red-100 text-red-900">
         <div class="max-w-screen-xl mx-auto px-4 lg:px-8">

--- a/code/javascripts/controllers/application_controller.js
+++ b/code/javascripts/controllers/application_controller.js
@@ -27,6 +27,7 @@ export default class extends Controller {
   focusSearch(event) {
     if (event.key === "/") {
       this.searchTarget.focus();
+      event.preventDefault();
     }
   }
 


### PR DESCRIPTION
There was a small typo in one of the examples of the homepage in the function definition.

Also, on Firefox with [Quick Find enabled](https://www.tenforums.com/tutorials/120679-enable-disable-quick-find-firefox.html), pressing `/` key didn't work since it opens quick find, so changed the event from `keyup` to `keydown` and prevented the default behavior.