### PR TITLE
Rename posts.sdl.js to proper file name

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -782,7 +782,7 @@ In this example, Redwood will look in `api/src/services/posts/posts.js` for the 
 - `updatePost({id, input})`
 - `deletePost({id})`
 
-To implement these, simply export them from the services file. They will usually get your data from a database, but they can do anything you want, as long as they return the proper types that Apollo expects based on what you defined in `posts.js.sdl`:
+To implement these, simply export them from the services file. They will usually get your data from a database, but they can do anything you want, as long as they return the proper types that Apollo expects based on what you defined in `posts.sdl.js`:
 
 ```javascript
 // api/src/services/posts/posts.js


### PR DESCRIPTION
The filename was not the same as actually being used.