### PR TITLE
Spread data to avoid HTTP status code 400

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1882,7 +1882,7 @@ const ContactPage = (props) => {
   const [create] = useMutation(CREATE_CONTACT)
 
   const onSubmit = (data) => {
-    create({ variables: { input: data }})
+    create({ variables: { input: ...data }})
     console.log(data)
   }
 


### PR DESCRIPTION
The docs have a mistake that results in bad GraphQL input:
GraphQL error]: Message: Variable "$input" got invalid value { data: { name: "AH", email: "B@b.com", message: "fsdaf" } }; Field "data" is not defined by type ContactInput.

<img width="1077" alt="Screen Shot 2020-03-13 at 8 04 45 PM" src="https://user-images.githubusercontent.com/8263430/76670247-ef5a5b80-6565-11ea-9008-355cd340daac.png">
