### PR TITLE
Tutorial 'side quest': Disambiguate reference to code listing.

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -785,7 +785,7 @@ In this example, Redwood will look in `api/src/services/posts/posts.js` for the 
 - `updatePost({id, input})`
 - `deletePost({id})`
 
-To implement these, simply export them from the services file. They will usually get your data from a database, but they can do anything you want, as long as they return the proper types that Apollo expects based on what you defined in `posts.sdl.js`:
+To implement these, simply export them from the services file. They will usually get your data from a database, but they can do anything you want, as long as they return the proper types that Apollo expects based on what you defined in `posts.sdl.js`.
 
 ```javascript
 // api/src/services/posts/posts.js


### PR DESCRIPTION
The phrase 'what you defined in posts.sdl.js:' ends in a colon,
followed by a code listing of _services/posts/posts.js_. The colon
leads the reader to believe that the source that follows is of
_posts.sdl.js_, rather than the source of _posts.js_.
(When I read it, I thought the code listing was showing the
wrong file - but it's the trailing colon that is misleading.)

Remove the colon to end the sentence, disambiguating the text
from the code listing that follows.