### PR TITLE
Tutorial: Correct ContactInput in generated sdl.

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1749,7 +1749,7 @@ export const schema = gql`
     contacts: [Contact]
   }
 
-  type ContactInput {
+  input ContactInput {
     name: String
     email: String
     message: String


### PR DESCRIPTION
The initial listing of contacts.sdl.js has a typo: it uses 'type'
for ContactInput, when it should be 'input'.

Replace 'type' with 'input' in the code snippet of contacts.sdl.js,
to match the generated gql schema.

See https://github.com/redwoodjs/redwood/issues/305#issuecomment-602308607
See https://github.com/redwoodjs/redwood/issues/317
