### PR TITLE
Lazyload hljs

### DIFF
--- a/code/javascripts/controllers/application_controller.js
+++ b/code/javascripts/controllers/application_controller.js
@@ -1,5 +1,4 @@
 import { Controller } from "stimulus";
-import hljs from "highlight.js";
 
 export default class extends Controller {
   static get targets() {
@@ -11,9 +10,13 @@ export default class extends Controller {
     this.yearTarget.textContent = new Date().getFullYear();
 
     // code highlighting
-    this.codeTargets.forEach(target => {
-      hljs.highlightBlock(target);
-    });
+    if (document.querySelector('code')) {
+      import('highlight.js').then(hljs => {
+        this.codeTargets.forEach(target => {
+          hljs.highlightBlock(target);
+        });
+      });
+    }
 
     // show the header logo unless we're on the homepage
     if (!this.isHomePage) {


### PR DESCRIPTION
Lazyloading hljs when there is code tag on a page might make a big difference when it comes to initial page load, especially that:
* hljs is a 3rd party dependency
* its very big
* it doesnt change very often

^ Which means its a great candidate to be cached by the browser.

---

Results in dev mode

Before:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/546845/77488686-397cf000-6e36-11ea-89db-9e609f230b90.png">


After:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/546845/77488661-1f431200-6e36-11ea-8d74-d291fb928454.png">

Those proportions are healthier, IMO :)


PS. I thin netlify preview should use production build to be more suitable for QA, it looks like assets are in dev mode, hence everything appears to be much slower than it will be in reality (hi Tailwind :) ).