### PR TITLE
Add webpack section

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -45,6 +45,10 @@ const SECTIONS = [
         pageBreakAtHeadingDepth: [1],
         url: 'redwoodjs/redwood/packages/router/README.md',
       },
+      {
+        pageBreakAtHeadingDepth: [1],
+        url: 'redwoodjs/redwood/docs/webpack.md',
+      },
     ],
   },
 ]


### PR DESCRIPTION
Adds a webpack section to Documentation (https://github.com/redwoodjs/redwood/pull/354) 

## Merge requirements:
https://github.com/redwoodjs/redwood/pull/354 

closes https://github.com/redwoodjs/redwood/issues/325