### PR TITLE
Add Linux setup instructions

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -44,12 +44,13 @@ Please do upgrade accordingly. Then proceed to the RedwoodJS installation when y
 >
 > **Yarn**
 >
-> - For **Mac** users, we recommend following the [Homebrew instructions via Yarnpkg.com](https://classic.yarnpkg.com/en/docs/install/#mac-stable).
-> - **Windows** users should also visit [Yarnpkg.com](https://classic.yarnpkg.com/en/docs/install/#windows-stable) for installation options.
+> - We recommend following the [instructions via Yarnpkg.com](https://classic.yarnpkg.com/en/docs/install/).
 >
 > **Node.js**
 >
-> - For **Mac** users, NVM is a great tool for managing multiple versions of Node on one system. And if you already have Homebrew installed, you can use it to [install NVM](https://formulae.brew.sh/formula/nvm) as well. It takes a bit more effort to set up and learn, however, in which case getting the latest [installation from Nodejs.org](https://nodejs.org/en/) works just fine.
+> - For **Linux** and **Mac** users, `nvm` is a great tool for managing multiple versions of Node on one system. It takes a bit more effort to set up and learn, however, in which case getting the latest [installation from Nodejs.org](https://nodejs.org/en/) works just fine.
+>   - For **Mac** users, if you already have Homebrew installed, you can use it to [install `nvm`](https://formulae.brew.sh/formula/nvm) as well. Otherwise, follow the [installation instructions from `nvm`](https://github.com/nvm-sh/nvm#installing-and-updating).
+>   - For **Linux** users, you can follow the [installation instructions from `nvm`](https://github.com/nvm-sh/nvm#installing-and-updating). 
 > - We recommend **Windows** users visit [Nodejs.org](https://nodejs.org/en/) for installation.
 >
 > If you're confused about which of the two current Node versions to use, we recommend using the most recent "even" LTS, which is currently v12.


### PR DESCRIPTION
There wasn't much reason to split out by OS for Yarn because their install instructions automatically detect your OS and show you the appropriate instructions. For Node, it was a little more complicated