### PR TITLE
Reference environmentVariables.md instead of environmentalVariables.md

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -48,7 +48,7 @@ const SECTIONS = [
       },
       {
         pageBreakAtHeadingDepth: [1],
-        url: 'redwoodjs/redwood/docs/environmentalVariables.md',
+        url: 'redwoodjs/redwood/docs/environmentVariables.md',
       },
       {
         pageBreakAtHeadingDepth: [1],


### PR DESCRIPTION
Parity with https://github.com/redwoodjs/redwood/pull/472

@thedavidprice @peterp 