### PR TITLE
fix schema.prisma provider value "postgres" --> "postgresql"

### DIFF
--- a/docs/localPostgresSetup.md
+++ b/docs/localPostgresSetup.md
@@ -24,7 +24,7 @@ Tell Prisma to use a Postgres database instead of SQLite by updating the `provid
 ```prisma
 // prisma/schema.prisma
 datasource DS {
-  provider = "postgres"
+  provider = "postgresql"
   url = env("DATABASE_URL")
 }
 ```


### PR DESCRIPTION
Per Prisma 2 docs, "postgres" is not allowed as a provider value:
https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-sources#fields