### PR TITLE
Edit local development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Other documentation is pulled from various READMEs in the main [redwoodjs/redwoo
 
 This codebase is built with https://cameronjs.com and relies on plain HTML pages and Javascript with a couple helpers built in to abstract things like partials and layouts. We use https://stimulusjs.org for the few sprinkles of interactivity throughout the site.
 
-Copy `.env.example` to a file named `.env` and get API keys/IDs for all of the service listed. Alternatively, if you don't care about populating search comment out the `require` statement for `search.js` in `lib/build.js` and the `publishSearch()` function call towards the end of the `main()` function.
+Copy `.env.example` to a file named `.env` and get API keys/IDs for all of the service listed. Alternatively, if you don't care about populating search comment out the `require` statement for `search.js` in `lib/build.js`, the `publishSearch()` function call towards the end of the `main()` function, and the `getObjectIDs()` function call at the beginning of the `main()` function.
 
-To build the tutorial and doc pages:
+Then build the tutorial and doc pages:
 
     yarn build
 
-To develop locally:
+And to develop locally:
 
     yarn dev
 


### PR DESCRIPTION
This PR edits the second paragraph of the [Local Development](https://github.com/redwoodjs/redwoodjs.com) section, providing instructions to comment out one more function call: `getObjectIDs()`.

In `build.js`, two functions are imported from `search.js`:
```
const { publish: publishSearch, getObjectIDs } = require('./search.js')
```

The original instructions in the Local Development section say to comment out the `require` statement and `publishSearch`, but don't mention `getObjectIDs`, which also has to commented out if we don't care about populating the search.

This PR also changes the wording slightly in the build and dev instructions because I didn't think it was clear that you _had_ to build before developing.

Let me know what you think, thanks!