### PR TITLE
[TUTORIAL] Adds notes about upgrading to Auth section

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2410,7 +2410,16 @@ There are a couple of places we need to add some code for authentication and luc
 yarn rw g auth netlify
 ```
 
-The generator adds one file and modifies a couple others. Take a look at the newly created `api/src/lib/auth.js` (usage comments omitted):
+The generator adds one file and modifies a couple others.
+
+> Don't see any changes?
+>
+> For this to work you must be on version `0.7.0` or greater of Redwood. If you
+> don't see any file changes, try
+> [upgrading](/reference/command-line-interface#upgrade) your Redwood packages
+> with `yarn rw upgrade`.
+
+Take a look at the newly created `api/src/lib/auth.js` (usage comments omitted):
 
 ```javascript
 // api/src/lib/auth.js


### PR DESCRIPTION
Closes #141

Adds a call out on the authentication page that `yarn rw g auth`requires Redwood >= 0.7.0.

![Screen Shot 2020-05-24 at 12 21 16 PM](https://user-images.githubusercontent.com/691365/82759158-89861d80-9db9-11ea-9721-7b7a55eb95a0.png)


## Note on placement

I decided to put it after `yarn rw g auth netlify` because that is where I got confused when running through the tutorial. 
