### PR TITLE
Fix copy formatting

### DIFF
--- a/code/javascripts/controllers/application_controller.js
+++ b/code/javascripts/controllers/application_controller.js
@@ -73,7 +73,7 @@ export default class extends Controller {
         new ClipboardJS('.copy-button', {
           text: (trigger) => {
             this._copiedMessage(trigger)
-            return this._stripComments(trigger.previousElementSibling.textContent)
+            return this._stripComments(trigger.previousElementSibling.innerText)
           },
         })
       }
@@ -92,9 +92,10 @@ export default class extends Controller {
   _stripComments(content) {
     let lines = content.split('\n')
 
-    if (lines[0].match(/^\/\//)) {
+    if (lines[0].match(/^\/\/|\*/)) {
       lines.shift()
-      if (lines[0].trim() === '') {
+      // remove empty lines after comments
+      while (lines[0].trim() === '') {
         lines.shift()
       }
     }


### PR DESCRIPTION
Closes #158 where the Copy button wasn't preserving line breaks.

To see the problem, go to https://redwoodjs.com/tutorial/a-second-page-and-a-link#back-home and click `Copy`. You should get this:

```
import { Link, routes } from '@redwoodjs/router'
const AboutPage = () => {
  return (
    <>      <header>        <h1>Redwood Blog</h1>        <nav>          <ul>            <li>              <Link to={routes.about()}>About</Link>            </li>          </ul>        </nav>      </header>      <main>        <p>          This site was created to demonstrate my mastery of Redwood: Look on my          works, ye mighty, and despair!        </p>        <Link to={routes.home()}>Return home</Link>      </main>    </>  )
}

export default AboutPage
``` 

Now, on the new deploy:

```
import { Link, routes } from '@redwoodjs/router'

const AboutPage = () => {
  return (

    <>
      <header>
        <h1>Redwood Blog</h1>
        <nav>
          <ul>
            <li>
              <Link to={routes.about()}>About</Link>
            </li>
          </ul>
        </nav>
      </header>
      <main>
        <p>
          This site was created to demonstrate my mastery of Redwood: Look on my
          works, ye mighty, and despair!
        </p>
        <Link to={routes.home()}>Return home</Link>
      </main>
    </>
  )
}

export default AboutPage
```

I also made it so that we're stripping CSS comments too because there's a CSS code block on https://deploy-preview-160--redwoodjs.netlify.app/tutorial/everyone-s-favorite-thing-to-build-forms#introducing-form-helpers.

@cannikin Any ill effects of exchanging `textContent` for `innerText`?