### PR TITLE
Indent "On this page" nav

### DIFF
--- a/lib/docutron.js
+++ b/lib/docutron.js
@@ -43,7 +43,8 @@ const convertToHtml = (pages, book, version) => {
     const content = md.render(page.text)
     const output = TEMPLATES.page({
       content,
-      links: subNav(page.text),
+      // Remove any top-level headers (i.e. #) b/c they're redundant
+      links: subNav(page.text).filter((header) => header.level > 1),
       nextPage: pages[index + 1],
       pageTitle: `${titleCase(book)} - ${page.title}`,
       version: version,
@@ -117,6 +118,9 @@ const subNav = (markdown) => {
       href: `#${paramCase(title.toLowerCase().replace(/&.*?;/g, ''))}`,
       level: headerLevelIndex,
       title: title,
+      // To indent headers according to the number of # they have.
+      // But since we remove #, which equal 1, we want to consider ## as 1 and indent from there.
+      ml: (headerLevelIndex - 2) * .75
     }
   })
 }

--- a/lib/templates/page.html.template
+++ b/lib/templates/page.html.template
@@ -4,10 +4,12 @@
   <aside class="hidden xl:block w-1/4 h-auto overflow-y-visible">
     <div class="overflow-y-auto sticky top-0 pl-6">
       <nav class="text-sm font-semibold text-gray-600 pt-8 pb-40 lg:py-12 overflow-y-auto h-screen" data-controller="aside" data-action="scroll->aside#saveScroll">
-        <h4 class="text-xs uppercase text-gray-500">On this page</h4>
+        <% if (links.length) {  %>
+          <h4 class="text-xs uppercase text-gray-500">On this page</h4>
+        <% } %>
         <ul class="mt-4 pointer-events-auto">
           <% links.forEach(link => { %>
-          <li class="my-1 py-1">
+          <li class="my-1 py-1" style="margin-left: ${link.ml}rem;">
             <a href="${link.href}">${link.title}</a>
           </li>
           <% }) %>


### PR DESCRIPTION
This PR adds indenting to the "On this page" nav. We're talking about this feature in #156. This is a way to see what it might look like/add it if we decide to go ahead. 

_Before_:

![rw-indent-before](https://user-images.githubusercontent.com/32992335/83358445-7975bd00-a328-11ea-886d-da0117a259b6.png)

_After_:

![rw-indent-after](https://user-images.githubusercontent.com/32992335/83358446-7d094400-a328-11ea-91d9-f2d31c1f3336.png)