### PR TITLE
Add table CSS

### DIFF
--- a/code/stylesheets/markdown.pcss
+++ b/code/stylesheets/markdown.pcss
@@ -105,4 +105,28 @@
   h6:hover .markdownIt-Anchor {
     visibility: visible;
   }
+
+  table {
+    @apply w-full text-left bg-red-100 rounded-t-lg;
+  }
+
+  th {
+    @apply p-2 bg-red-200;
+  }
+
+  th:first-child {
+    @apply rounded-tl-lg;
+  }
+
+  th:last-child {
+    @apply rounded-tr-lg;
+  }
+
+  td {
+    @apply p-2;
+  }
+
+  td code {
+    @apply bg-red-200 text-red-700 text-sm px-1 py-half rounded whitespace-no-wrap;
+  }
 }


### PR DESCRIPTION
Adds the CSS we agreed upon in #161. Now we can just write markdown tables like
```
|Option|Description|
|:-|:-|
|--verbose, v|Print more information while building.|
```
And they just get styled!