### PR TITLE
Persist scroll position of left nav when changing pages

### DIFF
--- a/code/html/layouts/application.html
+++ b/code/html/layouts/application.html
@@ -26,7 +26,7 @@
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
   </head>
 
-  <body class="relative bg-white text-gray-900 font-sans antialiased h-full flex flex-col" data-controller="application" data-action="keydown@window->application#focusSearch">
+  <body class="relative bg-white text-gray-900 font-sans antialiased h-full flex flex-col" data-controller="application" data-action="turbolinks:before-cache@document->application#saveScrollPosition keydown@window->application#focusSearch">
     <div class="flex-grow flex-shrink-0 flex-auto">
       <section class="bg-red-100 text-red-900">
         <div class="max-w-screen-xl mx-auto px-4 lg:px-8">
@@ -98,12 +98,12 @@
 
       <section id="main" class="max-w-screen-xl mx-auto px-8">
         <div class="flex">
-          <aside class="hidden absolute inset-0 mt-22 lg:mt-0 lg:mb-8 w-full lg:w-1/5 lg:static lg:block bg-white overflow-y-visible lg:px-0 z-10" data-target="application.nav">
+          <aside id="aside" class="hidden absolute inset-0 mt-22 lg:mt-0 lg:mb-8 w-full lg:w-1/5 lg:static lg:block bg-white overflow-y-visible lg:px-0 z-10" data-target="application.nav" data-turbolinks-permanent>
             <div class="lg:hidden mt-4 mx-4">
               @@include("search")
             </div>
             <div class="overflow-y-auto lg:sticky top-0 px-8 lg:px-0">
-              <nav class="text-sm font-semibold pt-8 pb-40 lg:py-12 pr-6 overflow-y-auto h-screen">
+              <nav class="text-sm font-semibold pt-8 pb-40 lg:py-12 pr-6 overflow-y-auto h-screen" data-action="navigated@document->application#restoreScrollPosition" data-target="application.innerNav">
                 @@include("nav")
               </nav>
             </div>

--- a/code/html/layouts/application.html
+++ b/code/html/layouts/application.html
@@ -28,7 +28,7 @@
 
   <body class="relative bg-white text-gray-900 font-sans antialiased h-full flex flex-col" data-controller="application" data-action="turbolinks:before-cache@document->application#saveScrollPosition keydown@window->application#focusSearch">
     <div class="flex-grow flex-shrink-0 flex-auto">
-      <section class="bg-red-100 text-red-900">
+      <section class="bg-red-100 text-red-900" data-target="application.header">
         <div class="max-w-screen-xl mx-auto px-4 lg:px-8">
           <header class="flex items-center justify-between border-b-2 border-white py-6">
             <a class="flex items-center text-2xl text-black font-bold tracking-tight" href="/">

--- a/code/javascripts/controllers/application_controller.js
+++ b/code/javascripts/controllers/application_controller.js
@@ -3,7 +3,7 @@ import hljs from 'highlight.js'
 
 export default class extends Controller {
   static get targets() {
-    return ['logo', 'search', 'nav', 'body', 'code', 'year']
+    return ['logo', 'search', 'nav', 'innerNav', 'body', 'code', 'year']
   }
 
   connect() {
@@ -36,6 +36,16 @@ export default class extends Controller {
     this.bodyTarget.classList.toggle('hidden')
     document.body.classList.toggle('fixed')
     document.body.classList.toggle('relative')
+  }
+
+  saveScrollPosition() {
+    window.navScrollPosition = this.innerNavTarget.scrollTop
+  }
+
+  restoreScrollPosition() {
+    if (window.navScrollPosition !== 0) {
+      this.innerNavTarget.scrollTop = window.navScrollPosition
+    }
   }
 
   _enableCopy() {

--- a/code/javascripts/controllers/application_controller.js
+++ b/code/javascripts/controllers/application_controller.js
@@ -3,7 +3,7 @@ import hljs from 'highlight.js'
 
 export default class extends Controller {
   static get targets() {
-    return ['logo', 'search', 'nav', 'innerNav', 'body', 'code', 'year']
+    return ['header', 'logo', 'search', 'nav', 'innerNav', 'body', 'code', 'year']
   }
 
   connect() {
@@ -40,11 +40,17 @@ export default class extends Controller {
 
   saveScrollPosition() {
     window.navScrollPosition = this.innerNavTarget.scrollTop
+    if (window.scrollY > this.headerTarget.offsetHeight) {
+      window.windowScrollPosition = this.headerTarget.offsetHeight
+    } else {
+      window.windowScrollPosition = window.scrollY
+    }
   }
 
   restoreScrollPosition() {
-    if (window.navScrollPosition !== 0) {
-      this.innerNavTarget.scrollTop = window.navScrollPosition
+    if (window.navScrollPosition !== 0 || window.windowScrollPosition !== 0) {
+      this.innerNavTarget.scrollTop = window.navScrollPosition || 0
+      window.scrollTo(null, window.windowScrollPosition || 0)
     }
   }
 

--- a/code/javascripts/controllers/nav_controller.js
+++ b/code/javascripts/controllers/nav_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
 
   connect() {
     this._highlightNav()
+    document.dispatchEvent(new Event('navigated'))
   }
 
   // opens/closes a nav section
@@ -22,7 +23,7 @@ export default class extends Controller {
   _highlightNav() {
     let linkFound = false
 
-    this.linkTargets.every((link) => {
+    this.linkTargets.forEach((link) => {
       if (this._linkDoesMatch(link)) {
         this._activateLink(link)
         linkFound = true


### PR DESCRIPTION
Re: https://github.com/redwoodjs/redwoodjs.com/issues/156#issuecomment-637077517

This feels much nicer, the nav doesn't jump around as you click on links and sections that you opened/closed stay that way forever (well, until a hard page reload).

/cc @jtoar @thedavidprice @weaversam8