### PR TITLE
Update tutorial for changes in auth generator

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2450,7 +2450,7 @@ export const getCurrentUser = async (jwt) => {
 
 export const requireAuth = () => {
   if (!context.currentUser) {
-    throw new AuthenticationError()
+    throw new AuthenticationError("You don't have permission to do that.")
   }
 }
 ```


### PR DESCRIPTION
From redwoodjs/redwood [#621](https://github.com/redwoodjs/redwood/pull/621#issue-425188052) -- The generator includes a string in `throw new AuthenticationError()`