### PR TITLE
Improve App Configuration doc

### DIFF
--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -1,47 +1,143 @@
 # App Configuration: redwood.toml
 
-Development environment settings can be adjusted using `redwood.toml`.
+You can configure your Redwood app's settings in `redwood.toml`. By default, `redwood.toml` lists the following configuration options:
+
+<!-- TODO -->
+<!-- toml syntax coloring not working here -->
+```toml
+[web]
+  port = 8910
+  apiProxyPath = "/.netlify/functions"
+[api]
+  port = 8911
+[browser]
+  open = true
+```
+
+These are listed by default because they're the ones that you're most likely to configure. But there are plenty more available. The rest are spread between Redwood's [webpack configuration files](https://github.com/redwoodjs/redwood/tree/main/packages/core/config) and `@redwoodjs/internal`'s [config.ts](https://github.com/redwoodjs/redwood/blob/main/packages/internal/src/config.ts#L42-L60):
+
+```javascript
+// redwood/packages/internal/src/config.ts
+
+const DEFAULT_CONFIG: Config = {
+  web: {
+    host: 'localhost',
+    port: 8910,
+    path: './web',
+    target: TargetEnum.BROWSER,
+    apiProxyPath: '/.netlify/functions',
+  },
+  api: {
+    host: 'localhost',
+    port: 8911,
+    path: './api',
+    target: TargetEnum.NODE,
+  },
+  browser: {
+    open: true,
+  },
+}
+```
+
+The options and their structure are based on Redwood's notion of sides and targets. Right now, Redwood has two fixed sides, api and web, that target NodeJS Lambdas and Browsers respectively. In the future, we'll add support for more sides and targets, like Electron and React Native (you can already see them listed as enums in [TargetEnum](https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/internal/src/config.ts#L11-L12)), and as we do, you'll see them reflected in `redwood.toml`. But right now, you'll most likely never touch options like `target`.
+
+The idea is that, in the future, changes here will have cascading, "app-level" effects. Using generators as an example, based on your side and target, the generators will behave differently, but appropriately different.
+
+> For the difference between a side and a target, see [Redwood File Structure](https://redwoodjs.com/tutorial/redwood-file-structure).
+
+You can think of `redwood.toml` as a convenience layer over Redwood's webpack configuration files. That is, for certain settings, instead of having to deal with webpack directly, we give you quick access via `redwood.toml`. Some of these settings are for development, some are for production, and some are for both. You can actually see this reflected in which webpack file each configuraiton option is referenced in&mdash;[webpack.development.js](https://github.com/redwoodjs/redwood/blob/main/packages/core/config/webpack.development.js), [webpack.production.js](https://github.com/redwoodjs/redwood/blob/main/packages/core/config/webpack.production.js), and [webpack.common.js](https://github.com/redwoodjs/redwood/blob/main/packages/core/config/webpack.common.js).
+
+<!-- https://github.com/redwoodjs/redwood/pull/152#issuecomment-593835518 -->
+`redwood.toml` also serves a slightly larger purpose: it's used to determine the base directory of a Redwood project. So this file is what really makes a Redwood app a Redwood app. If you remove it and run `yarn rw dev`, you'll get an error:
+
+```terminal
+Error: Could not find a "redwood.toml" file, are you sure you're in a Redwood project?
+```
+
+(So don't do that!)
 
 ## [web]
 
-This table contains the configuration for web side.
+Configuration for the web side.
 
-### web.host
+| Key                           | Description                        | Default                 | Context       |
+| :---------------------------- | :--------------------------------- | :---------------------- | :------------ |
+| `host`                        | Hostname to listen on              | `'localhost'`           | `development` |
+| `port`                        | Port to listen on                  | `8910`                  | `development` |
+| `path`                        | Path to the web side               | `'./web'`               | `both`        |
+| `target`                      | Target for the web side            | `TargetEnum.BROWSER`    | `both`        |
+| `apiProxyPath`                | Proxy path to the api side         | `'/.netlify/functions'` | `production`  |
+| `includeEnvironmentVariables` | Environment variables to whitelist |                         | `both`        |
 
-The hostname (string) to listen to for the web server, defaults to `localhost`. When running the server within containers/VMs, using `0.0.0.0` would allow network connections to/from the host.
+### apiProxyPath
 
-### web.port
+```toml
+[web]
+  apiProxyPath = "/.netlify/functions"
+```
 
-The port number (integer) to listen to for the web side.
+The path to the serverless functions. When you're running your app locally, this gets aliased away (you can see exactly how in [webpack.common.js](https://github.com/redwoodjs/redwood/blob/49c3afecc210709641dd340b974c86251ed207dc/packages/core/config/webpack.development.js#L21-L28) (and here's the docs on Webpack's [devServer.proxy](https://webpack.js.org/configuration/dev-server/#devserverproxy), for good measure)).
 
-### web.apiProxyPaths
-
-TODO
+Since Redwood plays nicely with Netlify, we use the [same proxy path](https://docs.netlify.com/functions/build-with-javascript) by default. If you're deploying elsewhere, you'll want to change this.
 
 ### includeEnvironmentVariables
+<!-- https://github.com/redwoodjs/redwood/issues/427 -->
+<!-- https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/core/config/webpack.common.js#L17-L31 -->
 
-The set of environment variable keys (list of strings) to include for the web side, in addition to any that are prefixed with `REDWOOD_ENV_`.
+```toml
+[web]
+  includeEnvironmentVariables = ['API_KEY']
+```
+
+Where `API_KEY` is defined in .env or .env.defaults:
+
+```plaintext
+API_KEY=...
+```
+
+`includeEnvironmentVariables` is the set of environment variables to whitelist for the web side. You can also prefix environment variables with `REDWOOD_ENV_` (see [Environment Variables](https://redwoodjs.com/docs/environment-variables#web)).
 
 ## [api]
 
-This table contains the configuration for api side.
+Configuration for the api side.
 
-## api.host
+| Key      | Description             | Default           | Context       |
+| :------- | :---------------------- | :---------------- | :------------ |
+| `host`   | Hostname to listen on   | `'localhost'`     | `development` |
+| `port`   | Port to listen on       | `8911`            | `development` |
+| `path`   | Path to the api side    | `'./web'`         | `both`        |
+| `target` | Target for the api side | `TargetEnum.NODE` | `both`        |
 
-The hostname (string) to listen to for the web server, defaults to `localhost`. When running the server within containers/VMs, using `0.0.0.0` would allow network connections to/from the host.
+## [browser]
 
-## api.port
+Configuration for the browser target.
 
-The port number (integer) to listen to for the api side.
+| Key    | Description                                  | Default | Context       |
+| :----- | :------------------------------------------- | :------ | :------------ |
+| `open` | Open the browser after the dev server starts | `false` | `development` |
 
-## browser.open
+### open
 
+```toml
+[browser]
+  open = true
 ```
-boolean = true string
+
+If you want your browser to stop opening when you `yarn rw dev`, set this to false. Or just remove it entirely.
+
+You can also provide the name of a browser to use instead of the system default. E.g., `open = 'Firefox'` will open Firefox regardless of which browser's the default on your system.
+
+There's a lot more you can do here. For all the details, see Webpack's docs on [devServer.open](https://webpack.js.org/configuration/dev-server/#devserveropen).
+
+## Running within a Container or VM
+
+To run a Redwood app within a container or VM, you'll want to set both the web and api's `host` to `0.0.0.0` to allow network connections to and from the host:
+
+```toml
+[web]
+  host = '0.0.0.0'
+  ...
+[api]
+  host = '0.0.0.0'
+  ...
 ```
-
-Tells the dev server to open the browser after server start. Defaults to false if config missing.
-
-Can instead provide a browser name to use instead of system default. E.g. `open = 'Firefox'` will auto-open in Firefox regardless of which browser is default.
-
-Uses Webpack. For more details see [Webpack devServer.open](https://webpack.js.org/configuration/dev-server/#devserveropen)


### PR DESCRIPTION
> Link to the new-and-improved App Configuration doc: https://deploy-preview-173--redwoodjs.netlify.app/docs/app-configuration-redwood-toml.
> See #156 for the tracking issue for all docs.

This PR improves the content in the [App Configuration](https://redwoodjs.com/docs/app-configuration-redwood-toml) (linking to the original here) doc. I think what I have is a good first draft, but I still need to ask some questions before I can consider it final (sorry this is so long):

### 1. `redwood.toml` is about...

The original doc says:

> Development environment settings can be adjusted using redwood.toml.

Is `redwood.toml` only about configuring the development environment? Would it be more instructive to say it's about configuring _redwood_ settings? Or is it really only about the development environment (like `browser.open` is pretty specific to dev)?

### 2. All the options

Did I get it right that what's in [config.ts](https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/internal/src/config.ts#L42-L60) is all the options? That is:

```javascript
const DEFAULT_CONFIG: Config = {
  web: {
    host: 'localhost',
    port: 8910,
    path: './web',
    target: TargetEnum.BROWSER,
    apiProxyPath: '/.netlify/functions',
    apiProxyPort: 8911,
  },
  api: {
    host: 'localhost',
    port: 8911,
    path: './api',
    target: TargetEnum.NODE,
  },
  browser: {
    open: true,
  },
}
```

**Update**: `includeEnvironmentVariables` is defined in webpack.common.js, so it's more nuanced than I thought.

### 3. Where do we specify the lambda functions dir? 

In the [Serverless Functions](https://redwoodjs.com/docs/serverless-functions) doc, we say:

> The dev server looks for "lambda functions" in the directory (default: ./api/src/functions) specified by your redwood.toml configuration file.

Where do we specify the lambda functions directory? Maybe [this issue](https://github.com/redwoodjs/redwood/issues/322#issuecomment-634418306) has the answer? Relevant excerpt here:

> 5. "Redwood's HTTP server for serverless Functions" is a mess. (Maybe the title specifically.) Two things:
>   - Move appropriate content to the redwood.toml doc section web.apiProxyPaths

### 4. Why do we only expose these by default?

Why do we only expose these by default in a Redwood app's `redwood.toml`?

```toml
[web]
  port = 8910
  apiProxyPath = "/.netlify/functions"
[api]
  port = 8911
[browser]
  open = true
```

I think the answer is "because you won't be changing the other ones", but just wanted to make sure (for the docs).

Also, I think it'd be nice if `redwood.toml` came commented, like

```toml
[web]
  # Port to listen on
  port = 8910
  # Proxy path to the api side. Our default is the same as netlifys
  apiProxyPath = "/.netlify/functions"
[api]
  # Port listen on...
  port = 8911
[browser]
  # whether or not the browser opens on yarn rw dev
  open = true
```

Maybe this looks a little busy. We don't have to comment on everything; but at the very least we could provide a header of sorts, like .[env.defaults](https://github.com/redwoodjs/create-redwood-app/blob/master/.env.defaults):

```toml
# This file contains the configuration settings for your Redwood app.
# By default, proxy path to the api side is the same as Netlify's
# For the full list of options, see config.ts: https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/internal/src/config.ts#L42-L60
```

### 5. `browser.open` default

[config.ts](https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/internal/src/config.ts#L42-L60) says `browser.open` defaults to true, but wanted to double check because I saw this issue come up recently on the forum: https://community.redwoodjs.com/t/stop-yarn-rw-dev-from-opening-browser-window/700/2.

**Update**: saw this line in [webpack.development.js](https://github.com/redwoodjs/redwood/blob/7d1840ab5e5fd02284b31f7077927a9a9b339e54/packages/core/config/webpack.development.js#L31-L32):

```javascript
// checks for override in redwood.toml, defaults to true
open: redwoodConfig.browser ? redwoodConfig.browser.open : false,
```

The comment seems to contradict the code?

### Thanks!