### PR TITLE
Disable turbolinks for anchor tags in the "On this page" nav

### DIFF
--- a/lib/templates/page.html.template
+++ b/lib/templates/page.html.template
@@ -10,7 +10,7 @@
         <ul class="mt-4 pointer-events-auto">
           <% links.forEach(link => { %>
           <li class="my-1 py-1" style="margin-left: ${link.ml}rem;">
-            <a href="${link.href}">${link.title}</a>
+            <a href="${link.href}" data-turbolinks="false">${link.title}</a>
           </li>
           <% }) %>
         </ul>


### PR DESCRIPTION
This PR closes #169 by disabling turbolinks for anchor tags in the "On this page" nav.

The nav_controller was disconnecting on every time we clicked a link in "On this page" nav, causing the custom navigate event to be dispatched and the window to scroll the top.

@cannikin I know next to nothing about turbolinks so let me know if we shouldn't be doing this! 