### PR TITLE
package.json: Explicity use yarn to make this work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "build": "node lib/build.js && webpack && postcss --verbose code/stylesheets/application.pcss -o publish/stylesheets/application.css",
     "clean": "del 'code/html/(cookbook|docs|tutorial)/*.html' 'code/html/_(cookbook|docs|tutorial)_nav.html' 'publish/!(downloads|images|favicon.*)'",
-    "dev": "$npm_execpath serve & $npm_execpath watch",
-    "netlify": "$npm_execpath watch & netlify dev",
-    "rebuild": "$npm_execpath clean && $npm_execpath build",
+    "dev": "yarn serve & yarn watch",
+    "netlify": "yarn watch & netlify dev",
+    "rebuild": "yarn clean && yarn build",
     "serve": "live-server --watch=./publish --mount=/:./publish --entry-file='publish/404.html'",
     "watch": "webpack --watch & postcss --verbose code/stylesheets/application.pcss -o publish/stylesheets/application.css --watch"
   },


### PR DESCRIPTION
Environment variables, like `$npm_execpath` are referenced using a different syntax on Windows. Windows uses `%npm_execpath%`. 

Even if we got the value of that env var, it's just a path to a .js file. And those aren't executable on Windows, so we would have to prefix it with `node `. 

And, if we did that, it would still only work with yarn, because `$npm_execpath watch` would have to be `$npm_execpath run watch` to work with npm

Explicitly just using `yarn` instead of that env var is easier to understand, and works on both Windows and Linux/Mac

(If we really want to support both npm and yarn I'd be happy to update this PR to use `cross-env` instead, and exploit the fact that yarn also allows the usage of `run`, which for npm is mandatory)