### PR TITLE
Fix error code field typo in third party api tutorial

### DIFF
--- a/cookbook/Third_Party_API.md
+++ b/cookbook/Third_Party_API.md
@@ -519,7 +519,7 @@ export const getWeather = async ({ zip }) => {
   )
   const json = await response.json()
 
-  if (json.code === '404') {
+  if (json.cod === '404') {
     return new Error(`${zip} isn't a valid US zip code, please try again`)
   }
 


### PR DESCRIPTION
Correct me if I'm missing something, but I believe that the openWeather API spelling for 'code' field is 'cod'. 
This fixes the third party api tutorial where there's use of `json.code` -> `json.cod`.

<img width="159" alt="Screenshot 2020-06-17 at 22 18 15" src="https://user-images.githubusercontent.com/16784959/84951537-7b8d9900-b0e8-11ea-8dc9-6cd1318728b4.png">
