### PR TITLE
Add Prisma primer

### DIFF
--- a/docs/prisma.md
+++ b/docs/prisma.md
@@ -10,7 +10,7 @@ Of those, Client is the one that's most important for you to grok, with Migrate 
 
 The Prisma-specific files and directories in a Redwood Project are:
 
-| File or Directory             | Description                               |
+| Files and Directories             | Description                               |
 |:------------------------------|:------------------------------------------|
 | `api/db`                      | Where your schema and migrations live     |
 | `api/src/lib/db.js`           | Where your Prisma Client lives            |
@@ -21,25 +21,11 @@ But it's something you really should know about, as it contains all your types!
 
 ## Configuring Prisma Client
 
-You can configure your Prisma Client in `api/src/lib/db.js` (here the relevant Prisma docs are **Reference** > **Tools & Interface** > **Prisma Client** > [**Constructor**](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/constructor)):
+You can configure Prisma Client in `api/src/lib/db.js` (here the relevant Prisma docs are **Reference** > **Tools & Interface** > **Prisma Client** > [**Constructor**](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/constructor)):
 
-```javascript{9}
+```javascript{4}
 // api/src/lib/db.js
-
 import { PrismaClient } from '@prisma/client'
 
 export const db = new PrismaClient()
-```
-
-Redwood doesn't do any configuring for you out of the box. 
-All `db.js` does is instantiate the Prisma Client as `db` and export it (for your Services—it's how they talk to the database).
-
-If you're really stuck and/or need to see what's going on at a more granular level for any reason, you can log anything you want with `log` and `db.on`:
-
-```javascript
-export const db = new PrismaClient({
-  log: [{ emit: 'event', level: 'query' }],
-})
-
-db.on(...)
 ```

--- a/docs/prisma.md
+++ b/docs/prisma.md
@@ -1,0 +1,45 @@
+# Prisma
+
+Prisma is one of Redwood's core technologies. 
+
+Prisma itself is a suite of tools.
+Of those, Redwood uses Prisma Client, Migrate, and Studio. (Which is nearly all of them!)
+Of those, Client is the one that's most important for you to grok, with Migrate coming in as a close second.
+
+## Prisma in Redwood 
+
+The Prisma-specific files and directories in a Redwood Project are:
+
+| File or Directory             | Description                               |
+|:------------------------------|:------------------------------------------|
+| `api/db`                      | Where your schema and migrations live     |
+| `api/src/lib/db.js`           | Where your Prisma Client lives            |
+| `node_modules/.prisma/client` | Where your Prisma Client _actually_ lives |
+
+The last one is subtle, hidden, and maybe even a little counterintuitive. 
+But it's something you really should know about, as it contains all your types!
+
+## Configuring Prisma Client
+
+You can configure your Prisma Client in `api/src/lib/db.js` (here the relevant Prisma docs are **Reference** > **Tools & Interface** > **Prisma Client** > [**Constructor**](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/constructor)):
+
+```javascript{9}
+// api/src/lib/db.js
+
+import { PrismaClient } from '@prisma/client'
+
+export const db = new PrismaClient()
+```
+
+Redwood doesn't do any configuring for you out of the box. 
+All `db.js` does is instantiate the Prisma Client as `db` and export it (for your Services—it's how they talk to the database).
+
+If you're really stuck and/or need to see what's going on at a more granular level for any reason, you can log anything you want with `log` and `db.on`:
+
+```javascript
+export const db = new PrismaClient({
+  log: [{ emit: 'event', level: 'query' }],
+})
+
+db.on(...)
+```

--- a/lib/build.js
+++ b/lib/build.js
@@ -110,6 +110,10 @@ const SECTIONS = [
       },
       {
         pageBreakAtHeadingDepth: [1],
+        url: './docs/prisma.md',
+      },
+      {
+        pageBreakAtHeadingDepth: [1],
         url: 'redwoodjs/redwood/packages/router/README.md',
       },
       {


### PR DESCRIPTION
WIP Prisma primer in response to the [Grokking Redwood](https://community.redwoodjs.com/t/groking-redwood/772) topic on the forum.

My working theory of difficulty, as someone who didn't really know TypeScript or Prisma (but now kind of does, or at least how they're related): we have to point users to `node_modules/.prisma/client`&mdash;the directory where Prisma Client lives, because the `index.d.ts` file there basically is your docs for your Prisma Client.

That or my intellisense was just never working.