### PR TITLE
Change code to HTML to have coloured highlights

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -963,7 +963,7 @@ Notice the `{id}`. Redwood calls these _route parameters_. They say "whatever va
 
 Cool, cool, cool. Now we need to construct a link that has the ID of a post in it:
 
-```javascript
+```html
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
 <Link to={routes.blogPost({ id: post.id })}>{post.title}</Link>


### PR DESCRIPTION
The section of the tutorial that [deals with Routing Params](https://redwoodjs.com/tutorial/routing-params) doesn't nicely highlight one of the code sections.

![image](https://user-images.githubusercontent.com/16005567/86994010-3ba35a00-c15a-11ea-99c4-cee114261743.png)

I adjusted the `.md` file to be the same as the other examples so the nice highlighting will work! Here is a screenshot post-change:

![image](https://user-images.githubusercontent.com/16005567/86994304-eddb2180-c15a-11ea-8a05-1a2091d01b9b.png)
