### PR TITLE
remove windows warning from tutorial

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -170,10 +170,6 @@ Let's give our users something to look at besides the Redwood welcome page. We'l
 
     yarn redwood generate page home /
 
-> ⚠️ **Windows Users:** You have to run `yarn redwood generate page home //` instead of the command above (notice the double slashes at the end). This is a known problem with Git for Windows.
->
-> We are tracking this issue [here](https://github.com/redwoodjs/redwood/issues/574). Apologies for the inconvenience!
-
 The command above does three things:
 
 - Creates `web/src/pages/HomePage/HomePage.js`. Redwood takes the name you specified as the first argument, capitalizes it, and appends "Page" to construct your new page component.


### PR DESCRIPTION
Generate page warning for Windows users is no longer needed as of this fix in v0.13.0:
https://github.com/redwoodjs/redwood/issues/574