### PR TITLE
Improve `body` Function param example to match netlify's API

### DIFF
--- a/cookbook/Custom_Function.md
+++ b/cookbook/Custom_Function.md
@@ -48,7 +48,7 @@ export const handler = async (event, context) => {
   return {
     statusCode: 200,
     headers: { 'Content-Type': 'application/json ' },
-    body: { time: new Date() },
+    body: JSON.stringify({ time: new Date() }),
   }
 }
 ```
@@ -73,7 +73,7 @@ export const handler = async (event, context) => {
   return {
     statusCode: 200,
     headers: { 'Content-Type': 'application/json ' },
-    body: { time: new Date() },
+    body: JSON.stringify({ time: new Date() }),
   }
 }
 ```
@@ -118,7 +118,7 @@ export const handler = async (event, context) => {
   return {
     statusCode: 200,
     headers: { 'Content-Type': 'application/json ' },
-    body: { time: new Date() },
+    body: JSON.stringify({ time: new Date() }),
   }
 }
 ```
@@ -166,7 +166,7 @@ export const handler = (event, context, callback) => {
   callback(null, {
     statusCode: 200,
     headers: { 'Content-Type': 'application/json ' },
-    body: { time: new Date() },
+    body: JSON.stringify({ time: new Date() }),
   })
 }
 ```


### PR DESCRIPTION
Running JSON examples after deploying them returns an error:
`json: cannot unmarshal object into Go struct field .body of type string`.

Netlify's Functions, just like AWS Lambda's, need the body to to be a string.