### PR TITLE
Serverless functions: `statusCode`

### DIFF
--- a/docs/serverlessFunctions.md
+++ b/docs/serverlessFunctions.md
@@ -16,6 +16,6 @@ supplied callback function to return a response:
 
 ```js
 export const handler = (event, context, callback) => {
-  return callback(null, { status: 200, body: 'Hello, world' })
+  return callback(null, { statusCode: 200, body: 'Hello, world' })
 }
 ```


### PR DESCRIPTION
The callback expects `statusCode`, not `status`.
The cookbook recipe has it right https://redwoodjs.com/cookbook/custom-function