### PR TITLE
Remove fixed position class as it was causing issues with certain layouts

### DIFF
--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.12.0" })
+@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.15.3" })
 @@contentFor("hero",
 <div class="bg-red-100">
   <div class="lg:flex lg:items-center max-w-screen-xl mx-auto px-8 py-12 md:py-20">

--- a/code/html/logos.html
+++ b/code/html/logos.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.12.0" })
+@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.15.3" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center pb-16">

--- a/code/html/stickers-thanks.html
+++ b/code/html/stickers-thanks.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.12.0" })
+@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.15.3" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center">

--- a/code/html/stickers.html
+++ b/code/html/stickers.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.12.0" })
+@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.15.3" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center">

--- a/code/javascripts/controllers/application_controller.js
+++ b/code/javascripts/controllers/application_controller.js
@@ -35,15 +35,11 @@ export default class extends Controller {
   toggleNav() {
     this.navTarget.classList.toggle('hidden')
     this.bodyTarget.classList.toggle('hidden')
-    document.body.classList.toggle('fixed')
-    document.body.classList.toggle('relative')
   }
 
   closeNav() {
     this.navTarget.classList.add('hidden')
     this.bodyTarget.classList.remove('hidden')
-    document.body.classList.remove('fixed')
-    document.body.classList.add('relative')
   }
 
   saveScrollPosition() {


### PR DESCRIPTION
This pull request is to address an issue with the menu bar layout. For certain screen sizes - namely iPad or similar sized screens in portrait orientation - the menu bar would resize when toggling the menu. Removing the toggle between fixed and relative classes when clicking on the menu appears to resolve the issue.