### PR TITLE
Implements async/await with error handling

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2201,7 +2201,7 @@ const ContactPage = () => {
     try {
       await create({ variables: { input: data } })
     } catch (error) {
-      debugger
+      console.log(error)
     }
   }
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2200,6 +2200,7 @@ const ContactPage = () => {
   const onSubmit = async (data) => {
     try {
       await create({ variables: { input: data } })
+      console.log(data)
     } catch (error) {
       console.log(error)
     }

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1943,9 +1943,13 @@ The `useMutation` hook returns a couple more elements along with the function to
 const ContactPage = () => {
   const [create, { loading, error }] = useMutation(CREATE_CONTACT)
 
-  const onSubmit = (data) => {
-    create({ variables: { input: data } })
-    console.log(data)
+  const onSubmit = async (data) => {
+    try {
+      await create({ variables: { input: data } })
+      console.log(data)
+    catch (error) {
+      console.log(error)
+    }
   }
 
   return (...)
@@ -2193,9 +2197,12 @@ const ContactPage = () => {
     },
   })
 
-  const onSubmit = (data) => {
-    create({ variables: { input: data } })
-    console.log(data)
+  const onSubmit = async (data) => {
+    try {
+      await create({ variables: { input: data } })
+    } catch (error) {
+      debugger
+    }
   }
 
   return (


### PR DESCRIPTION
This PR updates the example tutorial code for the `onSubmit` handler, removing confusion around GraphQL errors for newcomers.

I ran into the following error during the tutorial:

![Screen Shot 2020-08-10 at 8 28 02 PM](https://user-images.githubusercontent.com/151311/89844715-682c0680-db4a-11ea-85be-76f77fd63bc4.png)

We need to handle the thrown error by wrapping it in an async/await and catching the error as part of the `onSubmit`.