### PR TITLE
contributing.md: Link to our own CONTRIBUTING.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,7 +42,7 @@ Before you get started, there's an implicit doc-distinction that we should make 
 
 > The exceptions to this split are the packages that are designed to be used outside Redwood, which, right now, are `@redwoodjs/auth` and `@redwoodjs/router`.
 
-Although Developing and Contributing docs are in different places, they most definitely should be linked and referenced as needed. For example, it's appropriate to have a "Contributing" doc on redwoodjs.com that's context-appropriate, but it should link to the Framework's CONTRIBUTING.md (the way this doc does).
+Although Developing and Contributing docs are in different places, they most definitely should be linked and referenced as needed. For example, it's appropriate to have a "Contributing" doc on redwoodjs.com that's context-appropriate, but it should link to the Framework's [CONTRIBUTING.md](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md) (the way this doc does).
 
 ### How Redwood Thinks about Docs
 


### PR DESCRIPTION
We had the literal text `CONTRIBUTING.md` in the docs, which was automatically converted to a link by the markdown parser.

![image](https://user-images.githubusercontent.com/30793/89876733-5afd2f00-dbbf-11ea-9aa4-9e8c93215850.png)

![image](https://user-images.githubusercontent.com/30793/89876782-6ea89580-dbbf-11ea-8d66-82439abf4b17.png)

I've changed that to be an explicit link to our own CONTRIBUTING.md file in the github repo