### PR TITLE
Adds note around manually error handling

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2038,6 +2038,20 @@ We already capture any existing error in the `error` constant that we got from `
   // ...
 ```
 
+> If you need to handle your errors manually, you can do this:
+>
+> ```javascript{3-8}
+> // web/src/pages/ContactPage/ContactPage.js
+> const onSubmit = async (data) => {
+>   try {
+>     await create({ variables: { input: data } })
+>     console.log(data)
+>   catch (error) {
+>     console.log(error)
+>   }
+> }
+> ```
+
 To get a server error to fire, let's remove the email format validation so that the client-side error isn't shown:
 
 ```html


### PR DESCRIPTION
This PR addresses an issue I encountered during the tutorial around propagated thrown errors. 

## Background

As I was walking through the video tutorials I ran into an issue where I encountered a full GraphQL error page takeover after implementing the email contact validation on the API side. 

```
Unhandled Rejection (Error): GraphQL error: Can't create new contact.
```

I couldn't progress through the tutorial as a newcomer because I thought I had done something wrong. Turns out by adding the async/await and catching the error thrown from `create` - I could see the error (inline to the form) as presented in the videos and the written tutorial.

## Solution

We want to keep the simplicity of the tutorial, so I added a blockquote in case anyone runs into a similar issue or is interested in learning how to handle the errors manually. As per the discussion on #286 

## Changes

- Adds blockquote around manual error handling

refs #286 