### PR TITLE
Sorts releases by created date to find latest version

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const fetch = require('node-fetch')
 const { Octokit } = require('@octokit/rest')
+
 const octokit = Octokit({
   auth: process.env.GITHUB_AUTH,
   userAgent: 'RedwoodJS Builder; @octokit/rest',
@@ -64,7 +65,7 @@ const SECTIONS = [
       {
         pageBreakAtHeadingDepth: [1],
         url: './docs/deploy.md',
-      },      
+      },
       {
         pageBreakAtHeadingDepth: [1],
         url: './docs/environmentVariables.md',
@@ -151,7 +152,10 @@ const getLatestVersion = async () => {
     owner: 'redwoodjs',
     repo: 'redwood',
   })
-  const version = response.data[0].tag_name
+
+  const sortedReleases = response.data.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+
+  const version = sortedReleases[0].tag_name
   console.info(`For version ${version}`)
   return version
 }


### PR DESCRIPTION
When releasing v16.0, for some reason when building and fetching the latest release version, the releases were not sorted  chronologically:

```
v0.15.3
v0.15.0
v0.14.0
v0.13.0
v0.12.0
v0.11.0
v0.10.0
v0.8.2
v0.8.0
v0.8.0-rc.1
v0.7.0
v0.7.0-rc.3
v0.7.0-rc.2
v0.7.0-rc.1
v0.6.0
v0.6.0-rc.2
v0.6.0-rc.1
v0.5.0
v0.4.0
v0.3.2
v0.3.1
v0.3.0
v0.16.0
v0.2.5
v0.2.2
v0.2.0
v0.0.1-alpha.23
v0.0.1-alpha.22
v0.0.1-alpha.18
v0.0.0.alpha.4
For version v0.15.3
```

This PR sorts the releases by created_at and pulls the latest tag_name as the version.

![image (1)](https://user-images.githubusercontent.com/1051633/90813434-98fffe80-e2f5-11ea-9f3a-db7ad0f5fd8a.png)

