### PR TITLE
Issue #326 adds userMetadata to userAuth hook docs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -375,7 +375,8 @@ The following values are available from the `useAuth` hook:
 
 - async `logIn()`: Differs based on the client library, with Netlify Identity a pop-up is shown, and with Auth0 the user is redirected
 - async `logOut()`: Log out the current user
-- `currentUser`: an object containing information about the current user, or `null` if the user is not authenticated
+- `currentUser`: an object containing information about the current user as set on the `api` side, or `null` if the user is not authenticated.
+- `userMetadata`: The user's metadata (or user profile) fetched directly from an instance of the auth provider client, or `null` if the user is not authenticated
 - async `reauthenticate()`: Refetch the authentication data and populate the state.
 - async `getToken()`: returns a jwt
 - `client`: Access the instance of the client which you passed into `AuthProvider`

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -375,8 +375,8 @@ The following values are available from the `useAuth` hook:
 
 - async `logIn()`: Differs based on the client library, with Netlify Identity a pop-up is shown, and with Auth0 the user is redirected
 - async `logOut()`: Log out the current user
-- `currentUser`: an object containing information about the current user as set on the `api` side, or `null` if the user is not authenticated.
-- `userMetadata`: The user's metadata (or user profile) fetched directly from an instance of the auth provider client, or `null` if the user is not authenticated
+- `currentUser`: an object containing information about the current user as set on the `api` side, or `null` if the user is not authenticated
+- `userMetadata`: an object containing the user's metadata (or profile information) fetched directly from an instance of the auth provider client, or `null` if the user is not authenticated
 - async `reauthenticate()`: Refetch the authentication data and populate the state.
 - async `getToken()`: returns a jwt
 - `client`: Access the instance of the client which you passed into `AuthProvider`


### PR DESCRIPTION
Addresses https://github.com/redwoodjs/redwoodjs.com/issues/326 by adding description for `userMetadata` which was missing.

```
- `currentUser`: an object containing information about the current user as set on the `api` side, or `null` if the user is not authenticated
- `userMetadata`: an object containing the user's metadata (or profile information) fetched directly from an instance of the auth provider client, or `null` if the user is not authenticated
```
