### PR TITLE
Enhance Environment Variables doc

### DIFF
--- a/docs/environmentVariables.md
+++ b/docs/environmentVariables.md
@@ -132,25 +132,6 @@ node_modules
 yarn-error.log
 ```
 
-## Where Does Redwood Load My Environment Variables?
-
-For all the variables in your `.env` and `.env.defaults` files to make their way to `process.env`, there has to be a call to `dotenv`'s `config` function somewhere. So where is it?
-
-It's in [the CLI](https://github.com/redwoodjs/redwood/blob/main/packages/cli/src/index.js#L6-L12)&mdash;every time you run a `yarn rw` command:
-
-```javascript
-// packages/cli/src/index.js
-
-import { config } from 'dotenv-defaults'
-
-
-config({
-  path: path.join(getPaths().base, '.env'),
-  encoding: 'utf8',
-  defaults: path.join(getPaths().base, '.env.defaults'),
-})
-```
-
 ## Seeding your Database
 
 <!-- Source: https://github.com/motdotla/dotenv#should-i-have-multiple-env-files -->


### PR DESCRIPTION
This PR enhances the [Environment Variables](https://redwoodjs.com/docs/environment-variables) doc, and corresponds to issue #309. Right now, this PR justs:

- Removes the `Where Does Redwood Load My Environment Variables?` section