### PR TITLE
fix typescript docs nav link

### DIFF
--- a/lib/docutron.js
+++ b/lib/docutron.js
@@ -91,7 +91,7 @@ const splitToPages = (markdown, book, options = {}) => {
       title = options.title
     }
 
-    return { href: `/${book}/${paramCase(title)}.html`, title, text: section }
+    return { href: `/${book}/${paramCase(title, {splitRegexp: []})}.html`, title, text: section }
   })
 
   return groups


### PR DESCRIPTION
I noticed the TypeScript docs link in the RedwoodJS forum announcement for v0.17.0 is broken, but should be correct.

The TypeScript doc is currently live at https://redwoodjs.com/docs/type-script

I think the dash in "type-script" is a regex quirk.

For reference: [param-case docs](https://github.com/blakeembrey/change-case#options) and the [default split](https://github.com/blakeembrey/change-case/blob/d945e02b515cb8f7797328bcc5d6a29eb6c5832d/packages/no-case/src/index.ts#L11)

