### PR TITLE
Fix typo in useAuth() hook

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -711,7 +711,7 @@ You can also protect routes:
 </Router>
 ```
 
-And also protect content in pages or components via the `userAuth()` hook:
+And also protect content in pages or components via the `useAuth()` hook:
 
 ```js
 const { isAuthenticated, hasRole } = useAuth()


### PR DESCRIPTION
BEFORE 
`userAuth()` 
AFTER 
`useAuth()`

`useAuth` appears to be the correct hook name as referenced elsewhere