### PR TITLE
fix page title formatting for stand-alone pages like the Roadmap

### DIFF
--- a/lib/docutron.js
+++ b/lib/docutron.js
@@ -51,7 +51,7 @@ const convertToHtml = (pages, book, version) => {
       // Remove any top-level headers (i.e. #) b/c they're redundant
       links: subNav(page.text).filter((header) => header.level > 1),
       nextPage: pages[index + 1],
-      pageTitle: `${titleCase(book)} - ${page.title}`,
+      pageTitle: book ? `${titleCase(book)} - ${page.title}` : page.title,
       version: version,
     })
 


### PR DESCRIPTION
It's a little thing, but the [Roadmap page](https://redwoodjs.com/roadmap) title has a leading dash in a browser tab, ` - Roadmap : RedwoodJS Docs`, because, unlike most doc pages, it doesn't have a 'book' context.

