### PR TITLE
document yarn rw deploy command

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -561,7 +561,7 @@ Creates a data migration script in `api/prisma/dataMigrations`.
 
 See the [Data Migration](/docs/data-migrations) docs.
 
-### deploy
+### deploy (config)
 
 Generate a deployment configuration.
 

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -321,6 +321,20 @@ Using `--forward` (alias `--fwd`), you can pass one or more Webpack DevServer co
 ~/redwood-app$ yarn rw dev --fwd="--port=1234 --open=false"
 ```
 
+## deploy
+
+Deploy your redwood project.
+
+```
+yarn rw deploy <command>
+```
+
+<br/>
+
+| Command              | Description                                                                     |
+| :------------------- | :------------------------------------------------------------------------------ |
+| `api <provider>`     | Deploy the API using the selected provider                                      |
+
 ## destroy (alias d)
 
 Rollback changes made by the generate command.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -12,7 +12,7 @@ Currently, these are the officially supported deploy targets:
 - [Vercel](https://vercel.com)
 - [AWS-Serverless](https://serverless.com)
 
-Redwood has a CLI generator that adds the code and configuration required by the specified provider (see the [CLI Doc](https://redwoodjs.com/docs/cli-commands#deploy) for more information):
+Redwood has a CLI generator that adds the code and configuration required by the specified provider (see the [CLI Doc](https://redwoodjs.com/docs/cli-commands#deploy-config) for more information):
 ```shell
 yarn rw generate deploy <provider>
 ```


### PR DESCRIPTION
resolves #380 

This PR adds the `rw deploy` command to the CLI doc, but the section link takes precedence over the existing link for `rw generate deploy` listed in the sidebar `On This Page` nav menu. (Both point to `...docs/cli-commands.html#deploy`)

The link for the `rw generate deploy` section in my browser changes to "deploy-2", but the "On This Page" version doesn't.

Should I change the heading for the `generate deploy` command? Maybe `deploy config` or `deploy <provider>` would be clearer and resolve the link issue?