### PR TITLE
No page break headers in code blocks

### DIFF
--- a/lib/docutron.js
+++ b/lib/docutron.js
@@ -74,12 +74,18 @@ const splitToPages = (markdown, book, options = {}) => {
     }
   }
 
+  let isCodeBlock = false
+
   markdown.split('\n').forEach((line, index) => {
     if (options.skipLines && index < options.skipLines) {
       return
     }
 
-    if (shouldPageBreak(line) && buffer.length) {
+    if (line.match(/^```\w*$/)) {
+      isCodeBlock = !isCodeBlock
+    }
+
+    if (!isCodeBlock && shouldPageBreak(line) && buffer.length) {
       sections.push(buffer.join('\n'))
       buffer = []
     }


### PR DESCRIPTION
When parsing markdown files there is a function that looks for markdown headers and will automatically split the document in several pages at each header.

The problem is when there is a code block (text between triple backticks) that starts with the hash (#) character. This will incorrectly be interpreted as a markdown header and the page will be split in to several pages.

I made a quick edit to one of the existing documents to demonstrate.

This is how it should work (and how it works with my fix)

![after_code_header_fix](https://user-images.githubusercontent.com/30793/94798231-9eb32e80-03e1-11eb-8316-06edff78976a.png)

Notice the `# Terminal comment` string in the code block

Without this PR fix this is what happens:

Page 1
![before_code_header_fix_page1](https://user-images.githubusercontent.com/30793/94798436-e3d76080-03e1-11eb-846e-b4b3b22f0860.png)

Page 2
![before_code_header_fix_page2](https://user-images.githubusercontent.com/30793/94798530-049fb600-03e2-11eb-954b-1bdb61fa5867.png)

As you can see the page is split in two parts, and the formatting is all messed up on the second page