### PR TITLE
Add graphql highlighting support

### DIFF
--- a/lib/docutron.js
+++ b/lib/docutron.js
@@ -9,6 +9,8 @@ const highlightLines = require('markdown-it-highlight-lines')
 const markdownItTocAndAnchor = require('markdown-it-toc-and-anchor').default
 const markdownItCollapsible = require('markdown-it-collapsible')
 const hljs = require('highlight.js')
+const hljsDefineGraphQL = require("highlightjs-graphql");
+hljsDefineGraphQL(hljs);
 const md = require('markdown-it')({
   html: true,
   linkify: true,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clipboard": "^2.0.6",
     "dotenv": "^8.2.0",
     "highlight.js": "^9.18.1",
+    "highlightjs-graphql": "^1.0.2",
     "install": "^0.13.0",
     "lodash.clone": "^4.5.0",
     "lodash.escape": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,6 +2732,11 @@ highlight.js@^9.18.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
   integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
 
+highlightjs-graphql@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/highlightjs-graphql/-/highlightjs-graphql-1.0.2.tgz#841e26831e7da9f0a3d66f93e6ff98a0d1ad6f43"
+  integrity sha512-jShTftpKQDwMXc+7OHOpHXRYSweT08EO2YOIcLbwU00e9yuwJMYXGLF1eiDO0aUPeQU4/5EjAh5HtPt3ly7rvg==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
This PR adds a plugin to highlight.js to support syntax highlighting graphql code blocks in markdown files. 

Highlighting graphql code will look like this:

![image](https://user-images.githubusercontent.com/30793/94852597-6a179500-042a-11eb-8d40-e7d71aaf41e9.png)
