### PR TITLE
Fix docs link generation for camel case terms

### DIFF
--- a/lib/docutron.js
+++ b/lib/docutron.js
@@ -102,7 +102,7 @@ const splitToPages = (markdown, book, options = {}) => {
       title = options.title
     }
 
-    return { href: `/${book}/${paramCase(title)}.html`, title, text: section }
+    return { href: `/${book}/${paramCase(title.toLowerCase())}.html`, title, text: section }
   })
 
   return groups

--- a/netlify.toml
+++ b/netlify.toml
@@ -135,9 +135,21 @@ from = "/reference/redwood-form"
 to = "/docs/form"
 
 [[redirects]]
-from = "/docs/typescript"
-to = "/docs/type-script"
+from = "/docs/type-script"
+to = "/docs/typescript"
 
 [[redirects]]
 from ="/good-first-issue"
 to ="https://github.com/redwoodjs/redwood/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22"
+
+[[redirects]]
+from = "/docs/mocking-graph-ql-requests"
+to = "/docs/mocking-graphql-requests"
+
+[[redirects]]
+from = "/cookbook/mocking-graph-ql-in-storybook"
+to = "/cookbook/mocking-graphql-in-storybook"
+
+[[redirects]]
+from = "/cookbook/go-true-auth"
+to = "/cookbook/gotrue-auth"


### PR DESCRIPTION
resolves #374 

I noticed the camelCase split issue was resolved more straight-forwardly elsewhere in the same file:
https://github.com/redwoodjs/redwoodjs.com/blob/4d6d40b22b2a33c3b99297636193e9012ce9c543/lib/docutron.js#L148

so, this PR follows that pattern and calls `title.toLowerCase` as well

