### PR TITLE
Fix tutorial and doc links for local dev

### DIFF
--- a/lib/middleware/use-extension.js
+++ b/lib/middleware/use-extension.js
@@ -1,0 +1,37 @@
+// https://github.com/tapio/live-server/issues/244
+
+const fs = require('fs')
+const path = require('path')
+const rootDirectory = './publish/'
+const extensions = ['html']
+
+module.exports = function (req, res, next) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    return next()
+  }
+
+  if (req.url !== '/' && path.extname(req.url) === '') {
+    const requestedPath = req.url.replace('/', '')
+    let i = 0
+    const check = () => {
+      const path = rootDirectory + requestedPath + '.' + extensions[i]
+
+      fs.access(path, (err) => {
+        if (!err) {
+          req.url += '.' + extensions[i]
+          next()
+        } else {
+          if (++i >= extensions.length) {
+            next()
+          } else {
+            check()
+          }
+        }
+      })
+    }
+
+    check()
+  } else {
+    next()
+  }
+}

--- a/lib/middleware/use-headers.js
+++ b/lib/middleware/use-headers.js
@@ -1,0 +1,26 @@
+const fs = require('fs/promises')
+const toml = require('toml')
+
+const headers = {}
+
+fs.readFile('./netlify.toml').then((data) => {
+  toml.parse(data).headers.forEach((rule) => {
+    headers[rule.for] = Object
+      .entries(rule.values)
+      .map(([name, value]) => ({ name, value }))
+  })
+})
+
+module.exports = function (req, res, next) {
+  if (req.method === 'GET') {
+    const resHeaders = headers[req.url]
+
+    if (resHeaders) {
+      resHeaders.forEach((header) => {
+        res.setHeader(header.name, header.value)
+      })
+    }
+  }
+
+  next()
+}

--- a/lib/middleware/use-redirects.js
+++ b/lib/middleware/use-redirects.js
@@ -1,11 +1,26 @@
+const fs = require('fs/promises')
+const toml = require('toml')
+
+const redirects = {}
+
+fs.readFile('./netlify.toml').then((data) => {
+  toml.parse(data).redirects.forEach((rule) => {
+    const from = rule.from
+    redirects[from] = {
+      to: rule.to,
+      status: rule.status,
+    }
+  })
+})
+
 module.exports = function (req, res, next) {
   if (req.method === 'GET') {
-    if (req.url.endsWith('/tutorial/')) {
-      res.writeHead(302, { Location: '/tutorial/welcome-to-redwood.html' })
+    const rule = redirects[req.url]
+
+    if (rule) {
+      res.writeHead(rule.status || 301, { Location: rule.to })
       res.end()
-    } else if (req.url.endsWith('/docs/')) {
-      res.writeHead(302, { Location: '/docs/introduction.html' })
-      res.end()
+      return;
     }
   }
 

--- a/lib/middleware/use-redirects.js
+++ b/lib/middleware/use-redirects.js
@@ -1,0 +1,13 @@
+module.exports = function (req, res, next) {
+  if (req.method === 'GET') {
+    if (req.url.endsWith('/tutorial/')) {
+      res.writeHead(302, { Location: '/tutorial/welcome-to-redwood.html' })
+      res.end()
+    } else if (req.url.endsWith('/docs/')) {
+      res.writeHead(302, { Location: '/docs/introduction.html' })
+      res.end()
+    }
+  }
+
+  next()
+}

--- a/package.json
+++ b/package.json
@@ -7,13 +7,14 @@
     "dev": "yarn serve & yarn watch",
     "netlify": "yarn watch & netlify dev",
     "rebuild": "yarn clean && yarn build",
-    "serve": "live-server --watch=./publish --mount=/:./publish --entry-file='publish/404.html' --middleware=../../../lib/middleware/use-redirects",
+    "serve": "live-server --watch=./publish --mount=/:./publish --entry-file='publish/404.html' --middleware=../../../lib/middleware/use-extension --middleware=../../../lib/middleware/use-headers --middleware=../../../lib/middleware/use-redirects",
     "watch": "webpack --watch & postcss --verbose code/stylesheets/application.pcss -o publish/stylesheets/application.css --watch"
   },
   "private": true,
   "devDependencies": {
     "del-cli": "^3.0.0",
-    "live-server": "^1.2.1"
+    "live-server": "^1.2.1",
+    "toml": "^3.0.0"
   },
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "yarn serve & yarn watch",
     "netlify": "yarn watch & netlify dev",
     "rebuild": "yarn clean && yarn build",
-    "serve": "live-server --watch=./publish --mount=/:./publish --entry-file='publish/404.html'",
+    "serve": "live-server --watch=./publish --mount=/:./publish --entry-file='publish/404.html' --middleware=../../../lib/middleware/use-redirects",
     "watch": "webpack --watch & postcss --verbose code/stylesheets/application.pcss -o publish/stylesheets/application.css --watch"
   },
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6352,6 +6352,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
+
 tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"


### PR DESCRIPTION
When running `yarn dev` the two big buttons that link to the tutorial and the docs don't work. The links go to `/tutorial` and `/docs` which don't exist. I guess there is some redirect rule setup somewhere for redwoodjs.com that make them work in prod.

![image](https://user-images.githubusercontent.com/30793/95394259-5d001780-08fc-11eb-98bd-e226884a0387.png)

I've added a middleware to live-server that does that redirect when running locally.

I'm not super happy with how I had to specify the path to the middleware 😞 Please let me know if you want me to change this, and if so, any hints on how would be very appreciated.

Another thing is that this doesn't update the browser url. It still says localhost:8080/tutorial instead of localhost:8080/tutorial/welcome-to-redwood.html. I am not sure why. I thought 301 and 302 redirects would cause the url to update...