### PR TITLE
Add missing "}" in example code, "saving data" chapter

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2064,7 +2064,7 @@ We already capture any existing error in the `error` constant that we got from `
 >   try {
 >     await create({ variables: { input: data } })
 >     console.log(data)
->   catch (error) {
+>   } catch (error) {
 >     console.log(error)
 >   }
 > }


### PR DESCRIPTION
The try block was missing it's closing curly brace.
Changes to `/tutorial/saving-data#displaying-server-errors`