### PR TITLE
Change wording from GraphiQL to GraphQL Playground

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -320,7 +320,7 @@ yarn redwood dev [side..]
 
 **Usage**
 
-If you're only working on your sdl and services, you can run just the api server to get GraphiQL on port 8911:
+If you're only working on your sdl and services, you can run just the api server to get GraphQL Playground on port 8911:
 
 ```plaintext{10}
 ~/redwood-app$ yarn rw dev api


### PR DESCRIPTION
The GraphQL IDE available on port `8911` is currently "GraphQL Playground", not "GraphiQL" as currently stated.