### PR TITLE
redirect /newsletter to mailchimp signup url

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -153,3 +153,8 @@ to = "/cookbook/mocking-graphql-in-storybook"
 [[redirects]]
 from = "/cookbook/go-true-auth"
 to = "/cookbook/gotrue-auth"
+
+[[redirects]]
+  from = "/newsletter"
+  to = "https://redwoodjs.us19.list-manage.com/subscribe/post?u=0c27354a06a7fdf4d83ce07fc&id=09f634eea4"
+  force = true


### PR DESCRIPTION
I'm working on Issue 909 on the redwood framework, trying to encourage community engagement upon completion of the create-redwood-app script.

This PR adds a redirect in the netlify.toml so that `redwoodjs.com/newsletter` redirects to the unwieldy mailchimp url `https://redwoodjs.us19.list-manage.com/subscribe/post?u=0c27354a06a7fdf4d83ce07fc&id=09f634eea4`.

This way, I can add the cleaner `redwoodjs.com/newsletter` url to the copy at the end of the CRA script.

Cheers!