### PR TITLE
Adding a hint that changing local env vars requires restarting `yarn …

### DIFF
--- a/docs/environmentVariables.md
+++ b/docs/environmentVariables.md
@@ -151,7 +151,7 @@ config({
 })
 ```
 
-Remember, if `yarn rw dev` is already running, your local app won't reflect any changes you make to your `.env` until you stop and re-run `yarn rw dev`.
+Remember, if `yarn rw dev` is already running, your local app won't reflect any changes you make to your `.env` file until you stop and re-run `yarn rw dev`.
 
 ## Seeding your Database
 

--- a/docs/environmentVariables.md
+++ b/docs/environmentVariables.md
@@ -150,6 +150,7 @@ config({
   defaults: path.join(getPaths().base, '.env.defaults'),
 })
 ```
+Remember, if `yarn rw dev` is already running, your local app won't reflect any changes you make to your `.env` until you stop and re-run `yarn rw dev`.
 
 ## Seeding your Database
 

--- a/docs/environmentVariables.md
+++ b/docs/environmentVariables.md
@@ -150,6 +150,7 @@ config({
   defaults: path.join(getPaths().base, '.env.defaults'),
 })
 ```
+
 Remember, if `yarn rw dev` is already running, your local app won't reflect any changes you make to your `.env` until you stop and re-run `yarn rw dev`.
 
 ## Seeding your Database


### PR DESCRIPTION
…rw dev`

It took me far too long to realize this.