### PR TITLE
Add steps to invoke identity functions to RBAC cookbook

### DIFF
--- a/cookbook/Role-based_Access_Control.md
+++ b/cookbook/Role-based_Access_Control.md
@@ -634,6 +634,8 @@ netlify functions:invoke <function-name> --port 8910
 ```
 `<function-name>` should be replaced by `identity-validate`, `identity-signup`, `identity-login` or your own function.
 
+Note that the netlify-cli does not generate fake user data for each invocation of an identity function. It always provides the same `Test Person` data.
+
 ## Additional Resources
 
 - [RBAC Example & Demo Site](https://redwoodblog-with-identity.netlify.app/)

--- a/cookbook/Role-based_Access_Control.md
+++ b/cookbook/Role-based_Access_Control.md
@@ -618,6 +618,22 @@ export const handler = async (req, _context) => {
 }
 ```
 
+#### How to invoke serverless functions while in dev
+
+So long as `yarn rw dev` is running, `netlify-cli` can be used to invoke your function. Steps are:
+
+```terminal
+# Install the cli
+yarn add netlify-cli -g
+
+# Rebuild api after any changes to /functions
+yarn rw build api
+
+# Invoke your function with the CLI, pointing it to the rw dev port
+netlify functions:invoke <function-name> --port 8910
+```
+`<function-name>` should be replaced by `identity-validate`, `identity-signup`, `identity-login` or your own function.
+
 ## Additional Resources
 
 - [RBAC Example & Demo Site](https://redwoodblog-with-identity.netlify.app/)


### PR DESCRIPTION
I put some information on the forums
https://community.redwoodjs.com/t/testing-netlify-identity-triggers/1337
and @dthyresson asked I add some of the steps to the RBAC docs, I wasn't too sure how much detail to add so please let me know what to tweak.

Obviously my changes only apply to `cookbook/Role-based_Access_Control.md` though a number of files under version control seem to change with `yarn build` I wasn't sure if they should be commited or not, they're all in d7469e6. Let me know if I need to revert this commit.