### PR TITLE
Tutorial: Cells

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -817,7 +817,7 @@ export const Success = ({ posts }) => {
         <h2>{post.title}</h2>
       </header>
       <p>{post.body}</p>
-      <div>Posted at: <time datetime={post.createdAt}>{post.createdAt}</time></div>
+      <div>Posted at: {post.createdAt}</div>
     </article>
   ))
 }

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -682,16 +682,14 @@ export const Success = ({ blogPosts }) => {
 }
 ```
 
-> **Generator case insensitivity**
+> **Cell Generator Naming**
 >
-> When generating you can use any case you'd like and Redwood will do the right thing when it comes to naming. These will all create the same filename:
+> When generating cells you can use any case you'd like and Redwood will do the right thing when it comes to naming. However, for our use case you will need _some_ kind of indication that you're using more than one blog post. Calling `yarn redwood g cell blogposts` will generate a file at `web/src/components/BlogpostsCell/BlogpostsCell.js`. These will all create the same filename:
 >
 >     yarn rw g cell blog_posts
 >     yarn rw g cell blog-posts
 >     yarn rw g cell blogPosts
 >     yarn rw g cell BlogPosts
->
-> You will need _some_ kind of indication that you're using more than one word. Calling `yarn redwood g cell blogposts` will generate a file at `web/src/components/BlogpostsCell/BlogpostsCell.js`
 
 To get you off and running as quickly as possible the generator assumes you've got a root GraphQL query named the same thing as your cell and gives you the minimum query needed to get something out of the database. In this case it called the query `blogPosts`, which is not a valid query name for our existing Posts SDL and Service. (Go back to the [Creating a Post Editor section](https://redwoodjs.com/tutorial/getting-dynamic#creating-a-post-editor) in the *Getting Dynamic* part to see where these files come from.)
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -691,7 +691,7 @@ export const Success = ({ blogPosts }) => {
 >     yarn rw g cell blogPosts
 >     yarn rw g cell BlogPosts
 
-To get you off and running as quickly as possible the generator assumes you've got a root GraphQL query named the same thing as your cell and gives you the minimum query needed to get something out of the database. In this case it called the query `blogPosts`, which is not a valid query name for our existing Posts SDL and Service. (Go back to the [Creating a Post Editor section](https://redwoodjs.com/tutorial/getting-dynamic#creating-a-post-editor) in the *Getting Dynamic* part to see where these files come from.)
+To get you off and running as quickly as possible the generator assumes you've got a root GraphQL query named the same thing as your cell and gives you the minimum query needed to get something out of the database. In this case the query is called `blogPosts`:
 
 ```javascript
 // web/src/components/BlogPostsCell/BlogPostsCell.js
@@ -714,6 +714,8 @@ export const Success = ({ posts }) => {
   return JSON.stringify(posts)
 }
 ```
+
+However, this is not a valid query name for our existing Posts SDL (`src/graphql/posts.sdl.js`) and Service (`src/services/posts/posts.js`). (To see where these files come from, go back to the [Creating a Post Editor section](https://redwoodjs.com/tutorial/getting-dynamic#creating-a-post-editor) in the *Getting Dynamic* part.)
 
 We'll have to rename that to just `posts` in both the query name and prop named in `Success`:
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -685,7 +685,7 @@ export const Success = ({ blogPosts }) => {
 >
 > You will need _some_ kind of indication that you're using more than one word. Calling `yarn redwood g cell blogposts` will generate a file at `web/src/components/BlogpostsCell/BlogpostsCell.js`
 
-To get you off and running as quickly as possible the generator assumes you've got a root GraphQL query named the same thing as your cell and gives you the minimum query needed to get something out of the database. In this case it called the query `blogPosts`, which is not a valid query name for our existing Posts SDL and Service. (Check the [Creating a Post Editor section](https://redwoodjs.com/tutorial/getting-dynamic#creating-a-post-editor) in the *Getting Dynamic* part if you don't remember where these files came from.)
+To get you off and running as quickly as possible the generator assumes you've got a root GraphQL query named the same thing as your cell and gives you the minimum query needed to get something out of the database. In this case it called the query `blogPosts`, which is not a valid query name for our existing Posts SDL and Service. (Go back to the [Creating a Post Editor section](https://redwoodjs.com/tutorial/getting-dynamic#creating-a-post-editor) in the *Getting Dynamic* part to see where these files come from.)
 
 ```javascript
 // web/src/components/BlogPostsCell/BlogPostsCell.js

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -691,7 +691,7 @@ export const Success = ({ blogPosts }) => {
 >     yarn rw g cell blogPosts
 >     yarn rw g cell BlogPosts
 >
-> You just need _some_ kind of indication that you're using more than one word: either an underscore (`blog_posts`), hyphen (`blog-posts`), or capitalization of the next word (`blogPost`, `BlogPosts`). 
+> You will need _some_ kind of indication that you're using more than one word: either snake_case (`blog_posts`), kebab-case (`blog-posts`), camelCase (`blogPost`) or PascalCase (`BlogPosts`). 
 > 
 > Calling `yarn redwood g cell blogposts` (without any indication that we're using two words) will generate a file at `web/src/components/BlogpostsCell/BlogpostsCell.js`.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -597,7 +597,7 @@ Oh boy, our first page with data and we already have to worry about loading stat
 
 ## Cells
 
-These features are common in most web apps. We wanted to see if there was something we could do to make developers' lives easier when it comes to adding them to a typical component. We think we've come up with something to help. We call them _Cells_. Cells provide a simpler and more declarative approach to data fetching. (You can read the full documentation about Cells [here](https://redwoodjs.com/docs/cells).)
+These features are common in most web apps. We wanted to see if there was something we could do to make developers' lives easier when it comes to adding them to a typical component. We think we've come up with something to help. We call them _Cells_. Cells provide a simpler and more declarative approach to data fetching. ([Read the full documentation about Cells](https://redwoodjs.com/docs/cells).)
 
 When you create a cell you export several specially named constants and then Redwood takes it from there. A typical cell may look something like:
 
@@ -631,7 +631,7 @@ export const Success = ({ posts }) => {
 }
 ```
 
-When React renders this component Redwood will:
+When React renders this component, Redwood will:
 
 - Perform the `QUERY` and display the `Loading` component until a response is received
 - Once the query returns it will display one of three states:

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -682,7 +682,7 @@ export const Success = ({ blogPosts }) => {
 }
 ```
 
-> **Cell Generator Naming**
+> **Indicating Multiplicity to the Generator**
 >
 > When generating a cell you can use any case you'd like and Redwood will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogPostsCell/BlogPostsCell.js`):
 >

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -684,12 +684,16 @@ export const Success = ({ blogPosts }) => {
 
 > **Cell Generator Naming**
 >
-> When generating cells you can use any case you'd like and Redwood will do the right thing when it comes to naming. However, for our use case you will need _some_ kind of indication that you're using more than one blog post. Calling `yarn redwood g cell blogposts` will generate a file at `web/src/components/BlogpostsCell/BlogpostsCell.js`. These will all create the same filename:
+> When generating a cell you can use any case you'd like and Redwood will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogPostsCell/BlogPostsCell.js`):
 >
 >     yarn rw g cell blog_posts
 >     yarn rw g cell blog-posts
 >     yarn rw g cell blogPosts
 >     yarn rw g cell BlogPosts
+>
+> You just need _some_ kind of indication that you're using more than one word: either an underscore (`blog_posts`), hyphen (`blog-posts`), or capitalization of the new word (`blogPost`, `BlogPosts`). 
+> 
+> Calling `yarn redwood g cell blogposts` (without any indication that we're using two words) will generate a file at `web/src/components/BlogpostsCell/BlogpostsCell.js`.
 
 To get you off and running as quickly as possible the generator assumes you've got a root GraphQL query named the same thing as your cell and gives you the minimum query needed to get something out of the database. In this case the query is called `blogPosts`:
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -631,17 +631,16 @@ export const Success = ({ posts }) => {
 }
 ```
 
-When React renders this component, Redwood will:
+When React renders this component, Redwood will perform the `QUERY` and display the `Loading` component until a response is received.
 
-- Perform the `QUERY` and display the `Loading` component until a response is received
-- Once the query returns it will display one of three states:
+Once the query returns, it will display one of three states:
   - If there was an error, the `Failure` component
   - If the data return is empty (`null` or empty array), the `Empty` component
   - Otherwise, the `Success` component
 
-There are also some lifecycle helpers like `beforeQuery` (for massaging any props before being given to the `QUERY`) and `afterQuery` (for massaging the data returned from GraphQL but before being sent to the `Success` component)
+There are also some lifecycle helpers like `beforeQuery` (for massaging any props before being given to the `QUERY`) and `afterQuery` (for massaging the data returned from GraphQL but before being sent to the `Success` component).
 
-The minimum you need for a cell are the `QUERY` and `Success` exports. If you don't export an `Empty` component, empty results will be sent to your `Success` component. If you don't provide a `Failure` component you'll get error output sent to the console.
+The minimum you need for a cell are the `QUERY` and `Success` exports. If you don't export an `Empty` component, empty results will be sent to your `Success` component. If you don't provide a `Failure` component, you'll get error output sent to the console.
 
 A guideline for when to use cells is if your component needs some data from the database or other service that may be delayed in responding. Let Redwood worry about juggling what is displayed when and you can focus on the happy path of the final, rendered component populated with data.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -691,7 +691,7 @@ export const Success = ({ blogPosts }) => {
 >     yarn rw g cell blogPosts
 >     yarn rw g cell BlogPosts
 >
-> You will need _some_ kind of indication that you're using more than one word: either snake_case (`blog_posts`), kebab-case (`blog-posts`), camelCase (`blogPost`) or PascalCase (`BlogPosts`). 
+> You will need _some_ kind of indication that you're using more than one word: either snake_case (`blog_posts`), kebab-case (`blog-posts`), camelCase (`blogPosts`) or PascalCase (`BlogPosts`). 
 > 
 > Calling `yarn redwood g cell blogposts` (without any indication that we're using two words) will generate a file at `web/src/components/BlogpostsCell/BlogpostsCell.js`.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -813,7 +813,7 @@ export const Success = ({ posts }) => {
         <h2>{post.title}</h2>
       </header>
       <p>{post.body}</p>
-      <div>Posted at: <date>{post.createdAt}</date></div>
+      <div>Posted at: <time datetime={post.createdAt}>{post.createdAt}</time></div>
     </article>
   ))
 }

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -685,7 +685,31 @@ export const Success = ({ blogPosts }) => {
 >
 > You will need _some_ kind of indication that you're using more than one word. Calling `yarn redwood g cell blogposts` will generate a file at `web/src/components/BlogpostsCell/BlogpostsCell.js`
 
-To get you off and running as quickly as possible the generator assumes you've got a root GraphQL query named the same thing as your cell and gives you the minimum query needed to get something out of the database. In this case it called the query `blogPosts` which is not a valid query name for our existing Posts SDL and Service. We'll have to rename that to just `posts` in both the query name and prop named in `Success`:
+To get you off and running as quickly as possible the generator assumes you've got a root GraphQL query named the same thing as your cell and gives you the minimum query needed to get something out of the database. In this case it called the query `blogPosts`, which is not a valid query name for our existing Posts SDL and Service. (Check the [Creating a Post Editor section](https://redwoodjs.com/tutorial/getting-dynamic#creating-a-post-editor) in the *Getting Dynamic* part if you don't remember where these files came from.)
+
+```javascript
+// web/src/components/BlogPostsCell/BlogPostsCell.js
+
+export const QUERY = gql`
+  query BlogPostsQuery {
+    blogPosts {
+      id
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => <div>Error: {error.message}</div>
+
+export const Success = ({ posts }) => {
+  return JSON.stringify(posts)
+}
+```
+
+We'll have to rename that to just `posts` in both the query name and prop named in `Success`:
 
 ```javascript{5,17,18}
 // web/src/components/BlogPostsCell/BlogPostsCell.js

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -674,6 +674,8 @@ export const Success = ({ blogPosts }) => {
 }
 ```
 
+> **Generator case insensitivity**
+>
 > When generating you can use any case you'd like and Redwood will do the right thing when it comes to naming. These will all create the same filename:
 >
 >     yarn rw g cell blog_posts

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -781,7 +781,7 @@ export const Success = ({ posts }) => {
         <h2>{post.title}</h2>
       </header>
       <p>{post.body}</p>
-      <div>Posted at: {post.createdAt}</div>
+      <div>Posted at: <date>{post.createdAt}</date></div>
     </article>
   ))
 }

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -682,7 +682,7 @@ export const Success = ({ blogPosts }) => {
 }
 ```
 
-> **Indicating Multiplicity to the Generator**
+> **Indicating Multiplicity to the Cell Generator**
 >
 > When generating a cell you can use any case you'd like and Redwood will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogPostsCell/BlogPostsCell.js`):
 >

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -691,7 +691,7 @@ export const Success = ({ blogPosts }) => {
 >     yarn rw g cell blogPosts
 >     yarn rw g cell BlogPosts
 >
-> You just need _some_ kind of indication that you're using more than one word: either an underscore (`blog_posts`), hyphen (`blog-posts`), or capitalization of the new word (`blogPost`, `BlogPosts`). 
+> You just need _some_ kind of indication that you're using more than one word: either an underscore (`blog_posts`), hyphen (`blog-posts`), or capitalization of the next word (`blogPost`, `BlogPosts`). 
 > 
 > Calling `yarn redwood g cell blogposts` (without any indication that we're using two words) will generate a file at `web/src/components/BlogpostsCell/BlogpostsCell.js`.
 


### PR DESCRIPTION
Hello fellow RedwoodJS 🌲 folks,

I've added a few comments to clarify why I made the changes in this PR. 

Something else I wanted to ask: if I click the 'scaffolding' link below (won't work here, you can find it on the [Cells page](https://redwoodjs.com/tutorial/cells)) which links to [Creating a Post Editor on the Getting Dynamic tutorial page](https://redwoodjs.com/tutorial/getting-dynamic#creating-a-post-editor), it doesn't bring me to this section, just to the top of the page. Is this Issue-worthy?

> The browser should actually show an array with a number or two (assuming you created a blog post with our [scaffolding](/tutorial/getting-dynamic#creating-a-post-editor) from earlier). Neat!