### PR TITLE
Add missing `const`

### DIFF
--- a/docs/form.md
+++ b/docs/form.md
@@ -200,7 +200,7 @@ import { useMutation } from '@redwoodjs/web'
 const ContactPage = (props) => {
   const [create, { loading, error }] = useMutation(CREATE_CONTACT)
 
-  onSubmit = (data) => {
+  const onSubmit = (data) => {
     create({ variables: { input: data }})
   }
 


### PR DESCRIPTION
In one of the example the `const` was missing before a method declaration.