### PR TITLE
change login anchors to buttons in tutorial

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2686,9 +2686,9 @@ const BlogLayout = ({ children }) => {
             <Link to={routes.contact()}>Contact</Link>
           </li>
           <li>
-            <a href="#" onClick={logIn}>
+            <button onClick={logIn}>
               Log In
-            </a>
+            </button>
           </li>
         </ul>
       </nav>
@@ -2745,9 +2745,9 @@ const BlogLayout = ({ children }) => {
             <Link to={routes.contact()}>Contact</Link>
           </li>
           <li>
-            <a href="#" onClick={isAuthenticated ? logOut : logIn}>
+            <button onClick={isAuthenticated ? logOut : logIn}>
               {isAuthenticated ? 'Log Out' : 'Log In'}
-            </a>
+            </button>
           </li>
         </ul>
       </nav>
@@ -2790,9 +2790,9 @@ const BlogLayout = ({ children }) => {
             <Link to={routes.contact()}>Contact</Link>
           </li>
           <li>
-            <a href="#" onClick={isAuthenticated ? logOut : logIn}>
+            <button onClick={isAuthenticated ? logOut : logIn}>
               {isAuthenticated ? 'Log Out' : 'Log In'}
-            </a>
+            </button>
           </li>
           {isAuthenticated && <li>{currentUser.email}</li>}
         </ul>


### PR DESCRIPTION
The tutorial uses anchor tags in the authentication section to trigger Netlify identity modals. I think the best practice in this case is to use `<button>` elements instead, and it looks like that's what's in the code sample in `docs/authentication.md` as well.

Hope this is a useful PR, thanks for your consideration!