### PR TITLE
Fix :: Focusing on the search field on any keyboard layout

### DIFF
--- a/code/javascripts/controllers/application_controller.js
+++ b/code/javascripts/controllers/application_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
   }
 
   focusSearch(event) {
-    if (event.key === '/' && !this.someInputHasFocus) {
+    if (event.code === 'Slash' && !this.someInputHasFocus) {
       this.searchTarget.focus()
       event.preventDefault()
     }


### PR DESCRIPTION
The search input was not focused when "/" key was pressed. I don't know if it's Chrome bug or what, but when I press slash `event.key` was "." (dot). Any another keys was in another language. Looks like I'm typing with wrong layout, but when I trying to type something in search input or Chrome console - layout was English. So I propose to use `code` property of events.

**To Reproduce**

Steps to reproduce the behavior:
1. Go to home page
2. Press slash

**Expected behavior**
Search input focused

**Environment**
 - OS: Ubuntu 20.04.1 LTS
 - Browser: Version 86.0.4240.111 (Official Build) (64-bit)