### PR TITLE
Update tailwind setup CLI command

### DIFF
--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -169,10 +169,10 @@ Now, back in the browser, you'll see:
 
 This section is inspired by mdv.io's excellent blog post, [Adding Tailwind CSS to RedwoodJS](https://mdv.io/). Note that the `webpack.config.js` file is no longer necessary since Redwood's webpack configuration now comes with postcss-loader by default (see [Supported Extensions and Loaders](#supported-extensions-and-loaders)). Neither is PurgeCSS, since, as of Tailwind CSS v1.4, it's [built-in](https://tailwindcss.com/docs/release-notes/#tailwind-css-v1-4).
 
-> While following this example is a great way to learn about configuration in Redwood, do note that you can skip this section entirely and use the [Tailwind CSS generator](https://redwoodjs.com/docs/cli-commands#tailwind) instead:
+> While following this example is a great way to learn about configuration in Redwood, do note that you can skip this section entirely and use the [Tailwind CSS setup](https://redwoodjs.com/docs/cli-commands#setup) command instead:
 >
 > ```
-> yarn rw generate util tailwind
+> yarn rw setup tailwind
 > ```
 
 First, install the development dependencies:


### PR DESCRIPTION
Change command for installing tailwind from 'yarn rw generate util tailwind' to 'yarn rw setup tailwind'. 

'yarn rw generate util' is giving a deprecation warning in the CLI output.

Update link to cli-commands page for tailwind setup.