### PR TITLE
Adds CLI command doc section for Storybook

### DIFF
--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.16.0" })
+@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.21.0" })
 @@contentFor("hero",
 <div class="bg-red-100">
   <div class="lg:flex lg:items-center max-w-screen-xl mx-auto px-8 py-12 md:py-20">

--- a/code/html/logos.html
+++ b/code/html/logos.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.16.0" })
+@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.21.0" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center pb-16">

--- a/code/html/roadmap.html
+++ b/code/html/roadmap.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": " - Roadmap : RedwoodJS Docs", "version": "v0.16.0" })
+@@layout("application", { "title": "Roadmap : RedwoodJS Docs", "version": "v0.21.0" })
 
 @@contentFor("aside",
   <aside class="hidden xl:block w-1/4 h-auto overflow-y-visible">

--- a/code/html/stickers-thanks.html
+++ b/code/html/stickers-thanks.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.16.0" })
+@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.21.0" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center">

--- a/code/html/stickers.html
+++ b/code/html/stickers.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.16.0" })
+@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.21.0" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center">

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1170,6 +1170,27 @@ yarn rw setup <command>
 | `tailwind`          | Setup tailwindcss and PostCSS            |
 | `webpack`           | Setup webpack in your project so you can add custom config            |
 
+## storybook
+
+Starts Storybook locally 
+
+```terminal
+yarn rw storybook
+```
+
+<br/>
+
+[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+
+> "Props in, views out! Make it simple to reason about."
+
+RedwoodJS supports Storybook by creating stories when generating cells, components, layouts and pages. You can then use these to describe how to render that UI component with representative data.
+
+| Arguments & Options | Description                                                                                                                                    |
+| :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--open`            | Open Storybook in your browser on start
+| `--port`            | Which port to run Storybook on (defaults to 7910)
+
 ## test
 
 Run Jest tests for api and web.


### PR DESCRIPTION
Resolves https://github.com/redwoodjs/redwoodjs.com/issues/465

This PR adds a brief section to the CLI commands to document how to start Storybook and its two current options.

Note: this does not discuss what Storybook is in depth nor how to write stories.

Some wording/quotes is taken from original PR by @peterp to add Storybook support: https://github.com/redwoodjs/redwood/pull/742

