### PR TITLE
Revert "update Prisma's schema path everywhere"

### DIFF
--- a/cookbook/File_Upload.md
+++ b/cookbook/File_Upload.md
@@ -46,7 +46,7 @@ yarn rw dev
 We'll create a single model to store our image data:
 
 ```javascript
-//  api/db/schema.prisma
+// api/prisma/schema.prisma
 
 model Image {
   id    Int    @default(autoincrement()) @id

--- a/cookbook/Third_Party_API.md
+++ b/cookbook/Third_Party_API.md
@@ -295,7 +295,7 @@ Redwood comes with GraphQL integration built in so that seems like a logical way
 
 > **Doesn't Redwood have a generator for this?**
 >
-> Redwood does have an SDL generator, but it assumes you have a model defined in ` api/db/schema.prisma` and so creates the SDL you need to access that data structure. If you're creating a custom one you're on your own!
+> Redwood does have an SDL generator, but it assumes you have a model defined in `api/prisma/schema.prisma` and so creates the SDL you need to access that data structure. If you're creating a custom one you're on your own!
 
 ### The GraphQL API
 

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -114,14 +114,14 @@ yarn rw dataMigrate <command>
 
 | Command   | Description                                                                                     |
 | :-------- | :---------------------------------------------------------------------------------------------- |
-| `install` | Appends `DataMigration` model to `schema.prisma`, creates ` api/db/dataMigrations` directory |
+| `install` | Appends `DataMigration` model to `schema.prisma`, creates `api/prisma/dataMigrations` directory |
 | `up`      | Executes oustanding data migrations                                                             |
 
 ### install
 
 - Appends a `DataMigration` model to `schema.prisma` for tracking which data migrations have already run.
 - Creates a DB migration using `yarn rw db save 'create data migrations`.
-- Creates ` api/db/dataMigrations` directory to contain data migration scripts
+- Creates `api/prisma/dataMigrations` directory to contain data migration scripts
 
 ```terminal
 yarn rw dataMigrate install
@@ -129,7 +129,7 @@ yarn rw dataMigrate install
 
 ### up
 
-Executes outstanding data migrations against the database. Compares the list of files in ` api/db/dataMigrations` to the records in the `DataMigration` table in the database and executes any files not present.
+Executes outstanding data migrations against the database. Compares the list of files in `api/prisma/dataMigrations` to the records in the `DataMigration` table in the database and executes any files not present.
 
 If an error occurs during script execution, any remaining scripts are skipped and console output will let you know the error and how many subsequent scripts were skipped.
 
@@ -151,7 +151,7 @@ yarn rw db <command>
 | :----------------- | :-------------------------------------------------------------------------------------------------------- |
 | `down [decrement]` | Migrate your database down                                                                                |
 | `generate`         | Generate the Prisma client                                                                                |
-| `introspect`       | Introspect your database and generate models in `./ api/db/schema.prisma`, overwriting existing models |
+| `introspect`       | Introspect your database and generate models in `./api/prisma/schema.prisma`, overwriting existing models |
 | `save [name..]`    | Create a new migration                                                                                    |
 | `seed`             | Seed your database with test data                                                                         |
 | `studio`           | Start Prisma Studio                                                                                       |
@@ -178,7 +178,7 @@ yarn rw db down [decrement]
 Given the following migrations,
 
 ```plaintext{2,4}
- api/db/migrations/
+api/prisma/migrations/
 ├── 20200518160457-create-users  <-- desired
 ├── 20200518160621-add-profiles
 ├── 20200518160811-add-posts     <-- current
@@ -204,7 +204,7 @@ This means that `yarn rw db generate` needs to be run after every change to your
 
 ### introspect
 
-Introspect your database and generate models in `./ api/db/schema.prisma`, overwriting existing models.
+Introspect your database and generate models in `./api/prisma/schema.prisma`, overwriting existing models.
 
 ```terminal
 yarn rw db introspect
@@ -229,7 +229,7 @@ A migration defines the steps necessary to update your current schema.
 Running `yarn rw db save` generates the following directories and files as necessary:
 
 ```terminal
- api/db/migrations
+api/prisma/migrations
 ├── 20200516162516-create-users
 │   ├── README.md
 │   ├── schema.prisma
@@ -254,7 +254,7 @@ Seed your database with test data.
 yarn rw db seed
 ```
 
-Runs `seed.js` in `./ api/db`. `seed.js` instantiates the Prisma client and provides an async main function where you can put any seed data&mdash;data that needs to exist for your app to run. See the [example blog's seed.js file](https://github.com/redwoodjs/example-blog/blob/master/ api/db/seeds.js).
+Runs `seed.js` in `./api/prisma`. `seed.js` instantiates the Prisma client and provides an async main function where you can put any seed data&mdash;data that needs to exist for your app to run. See the [example blog's seed.js file](https://github.com/redwoodjs/example-blog/blob/master/api/prisma/seeds.js).
 
 ### studio
 
@@ -288,7 +288,7 @@ yarn rw db up [increment]
 Given the following migrations
 
 ```plaintext{2,4}
- api/db/migrations/
+api/prisma/migrations/
 ├── 20200518160457-create-users  <-- current
 ├── 20200518160621-add-profiles
 ├── 20200518160811-add-posts     <-- desired
@@ -549,7 +549,7 @@ Generate a data migration script.
 yarn rw generate dataMigration <name>
 ```
 
-Creates a data migration script in ` api/db/dataMigrations`.
+Creates a data migration script in `api/prisma/dataMigrations`.
 
 | Arguments & Options | Description                                                              |
 | :------------------ | :----------------------------------------------------------------------- |

--- a/docs/dataMigrations.md
+++ b/docs/dataMigrations.md
@@ -21,12 +21,12 @@ Rather than create this model by hand, Redwood includes a CLI tool to add the mo
 
     yarn rw dataMigrate install
 
-You'll see a new directory created at ` api/db/dataMigrations` which will store our individual migration tasks.
+You'll see a new directory created at `api/prisma/dataMigrations` which will store our individual migration tasks.
 
 Take a look at `schema.prisma` to see the new model definition:
 
 ```javascript
-//  api/db/schema.prisma
+// api/prisma/schema.prisma
 
 model DataMigration {
   version    String   @id
@@ -52,10 +52,10 @@ To create a data migration we have a generator:
 
     yarn rw generate dataMigration copyPreferences
 
-This will create ` api/db/dataMigrations/20200721123456-copy-preferences.js`:
+This will create `api/prisma/dataMigrations/20200721123456-copy-preferences.js`:
 
 ```javascript
-//  api/db/dataMigrations/20200721123456-copy-preferences.js
+// api/prisma/dataMigrations/20200721123456-copy-preferences.js
 
 export default async ({ db }) => {
   // Migration here...
@@ -69,7 +69,7 @@ export default async ({ db }) => {
 Now it's up to you to define your data migration. In our user/preference example, it may look something like:
 
 ```javascript
-//  api/db/dataMigrations/20200721123456-copy-preferences.js
+// api/prisma/dataMigrations/20200721123456-copy-preferences.js
 
 const asyncForEach = async (array, callback) => {
   for (let index = 0; index < array.length; index++) {
@@ -112,7 +112,7 @@ When you're ready, you can execute your data migration with `dataMigrate`'s `up`
 
     yarn rw dataMigrate up
 
-This goes through each file in ` api/db/dataMigrations`, compares it against the list of migrations that have already run according to the `DataMigration` table in the database, and executes any that aren't present in that table, sorted oldest to newest based on the timestamp in the filename.
+This goes through each file in `api/prisma/dataMigrations`, compares it against the list of migrations that have already run according to the `DataMigration` table in the database, and executes any that aren't present in that table, sorted oldest to newest based on the timestamp in the filename.
 
 Any logging statements (like `console.info()`) you include in your data migration script will be output to the console as the script is running.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,7 +35,7 @@ yarn rw build && yarn rw db up --no-db-client --auto-approve && yarn rw dataMigr
 ```
 
 ### 3. Prisma and Database
-Redwood uses Prisma for managing database access and migrations. The settings in ` api/db/schema.prisma` must include the correct deployment database, e.g. postgresql, and the database connection string.
+Redwood uses Prisma for managing database access and migrations. The settings in `api/prisma/schema.prisma` must include the correct deployment database, e.g. postgresql, and the database connection string.
 
 It is possible to use a different database type for local development and production. To do this, you need to use the Prisma dynamic provider syntax. For example, to use SQLite locally and PostgreSQL in production, include this in your `schema.prisma`:
 ```javascript

--- a/docs/environmentVariables.md
+++ b/docs/environmentVariables.md
@@ -157,10 +157,10 @@ Remember, if `yarn rw dev` is already running, your local app won't reflect any 
 
 <!-- Source: https://github.com/motdotla/dotenv#should-i-have-multiple-env-files -->
 
-You can provide an `.env` file just for seeding your database. A Redwood app's seed file (` api/db/seed.js`) is setup to load it into `process.env`:
+You can provide an `.env` file just for seeding your database. A Redwood app's seed file (`api/prisma/seed.js`) is setup to load it into `process.env`:
 
 ```javascript{5-7}
-//  api/db/seed.js
+// api/prisma/seed.js
 
 /* eslint-disable no-console */
 const { PrismaClient } = require('@prisma/client')
@@ -173,7 +173,7 @@ const db = new PrismaClient()
 
 ```
 
-So ` api/db` you make an `.env` file in ` api/db` with environment variables:
+So `api/prisma` you make an `.env` file in `api/prisma` with environment variables:
 
 ```
 SEEDING_MESSAGE=seeding the database...

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,7 +33,7 @@ Take a visit to the [CLI Doc](https://redwoodjs.com/docs/cli-commands.html) to s
 
 Redwood generators make monotonous developer tasks a breeze. Creating all the boilerplate code required for CRUD operations on a model can be accomplished with a few commands. Three to be exact. 
 
-Every new Redwood project comes with a default Model called UserExample in ` api/db/schema.prisma`. 
+Every new Redwood project comes with a default Model called UserExample in `api/prisma/schema.prisma`. 
 
 ```
 model UserExample {

--- a/docs/schemaRelations.md
+++ b/docs/schemaRelations.md
@@ -2,7 +2,7 @@
 
 > When the Scaffold Generator is used on a relational data model, the resulting code will _not_ work without manual modifications. The following explains what is happening and provides a workaround.
 
-Redwood uses Prisma for handling the database connection, migrations, and queries. You can configure both the database connection and data structure in ` api/db/schema.prisma`. (For the full Prisma Schema documentation, [click here](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema).)
+Redwood uses Prisma for handling the database connection, migrations, and queries. You can configure both the database connection and data structure in `api/prisma/schema.prisma`. (For the full Prisma Schema documentation, [click here](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema).)
 
 A typical `schema.prisma` includes many [data models](http://prisma.io/docs/reference/tools-and-interfaces/prisma-schema/models), which map to tables in a relational DB (and will map to collections in MongoDB). To create connections between these models, you'll need to use a powerful Prisma feature called *Relations*. The schema syntax for a Relation is `@relation`.
 


### PR DESCRIPTION
Reverts redwoodjs/redwoodjs.com#480. Accidentally included a space before `api` that I missed.