### PR TITLE
Firebase auth provider docs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -662,6 +662,21 @@ None.
 
 #### Add Application hasRole Support in Firebase
 
+#### Auth Providers
+
+Providers can be configured by specifying `logIn(provider)` and `signUp(provider)`.
+
+Supported providers:
+
+- google.com (Default)
+- facebook.com
+- github.com
+- twitter.com
+- microsoft.com
+- apple.com
+
+Email/password authentication is supported by calling `login({ username, password })` and `signUp({ username, password })`.
+
 +++
 
 #### Netlify Identity


### PR DESCRIPTION
Adds documentation about Firebase providers. Section on email provider requires merge of https://github.com/redwoodjs/redwood/pull/1555.