### PR TITLE
Replaced findOne with findUnique in docs

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -922,7 +922,7 @@ export const posts = () => {
 }
 
 export const post = ({ id }) => {
-  return db.post.findOne({
+  return db.post.findUnique({
     where: { id },
   })
 }
@@ -2647,7 +2647,7 @@ export const posts = () => {
 }
 
 export const post = ({ id }) => {
-  return db.post.findOne({
+  return db.post.findUnique({
     where: { id },
   })
 }
@@ -2675,7 +2675,7 @@ export const deletePost = ({ id }) => {
 }
 
 export const Post = {
-  user: (_obj, { root }) => db.post.findOne({ where: { id: root.id } }).user(),
+  user: (_obj, { root }) => db.post.findUnique({ where: { id: root.id } }).user(),
 }
 ```
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -922,7 +922,7 @@ export const posts = () => {
 }
 
 export const post = ({ id }) => {
-  return db.post.findUnique({
+  return db.post.findOne({
     where: { id },
   })
 }
@@ -2647,7 +2647,7 @@ export const posts = () => {
 }
 
 export const post = ({ id }) => {
-  return db.post.findUnique({
+  return db.post.findOne({
     where: { id },
   })
 }
@@ -2675,7 +2675,7 @@ export const deletePost = ({ id }) => {
 }
 
 export const Post = {
-  user: (_obj, { root }) => db.post.findUnique({ where: { id: root.id } }).user(),
+  user: (_obj, { root }) => db.post.findOne({ where: { id: root.id } }).user(),
 }
 ```
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -513,7 +513,7 @@ Our recommendation is to create a `src/lib/auth.js|ts` file that exports a `getC
 import { getCurrentUser } from 'src/lib/auth'
 // Example:
 //  export const getCurrentUser = async (decoded) => {
-//    return await db.user.findOne({ where: { decoded.email } })
+//    return await db.user.findUnique({ where: { decoded.email } })
 //  }
 //
 
@@ -717,7 +717,7 @@ export const getCurrentUser = async (_decoded, { token }) => {
   const mAdmin = new Magic(process.env.MAGICLINK_SECRET)
   const { email, publicAddress, issuer } = await mAdmin.users.getMetadataByToken(token)
 
-  return await db.user.findOne({ where: { issuer } })
+  return await db.user.findUnique({ where: { issuer } })
 }
 ```
 
@@ -801,13 +801,13 @@ You can specify an optional role in `requireAuth` to check if the user is both a
 export const myThings = () => {
   requireAuth({ role: 'admin' })
 
-  return db.user.findOne({ where: { id: context.currentUser.id } }).things()
+  return db.user.findUnique({ where: { id: context.currentUser.id } }).things()
 }
 
 export const myBooks = () => {
   requireAuth({ role: ['author', 'editor'] })
 
-  return db.user.findOne({ where: { id: context.currentUser.id } }).books()
+  return db.user.findUnique({ where: { id: context.currentUser.id } }).books()
 }
 ```
 

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1064,7 +1064,7 @@ export const users = () => {
 
 export const User = {
   profile: (_obj, { root }) => {
-    db.user.findOne({ where: { id: root.id } }).profile(),
+    db.user.findUnique({ where: { id: root.id } }).profile(),
   }
 }
 ```


### PR DESCRIPTION
Prisma release 2.12.0 renames findOne to findUnique and deprecates findOne. I have simply replaced various instances of findOne in the docs with findUnique.
This should close issue #505 . 

