### PR TITLE
Remove key prop from BlogPost

### DIFF
--- a/TUTORIAL2.md
+++ b/TUTORIAL2.md
@@ -215,7 +215,7 @@ export const Success = ({ posts }) => {
     <div className="-mt-10">
       {posts.map((post) => (
         <div key={post.id} className="mt-10">
-          <BlogPost key={post.id} post={post} summary={true} />
+          <BlogPost post={post} summary={true} />
         </div>
       ))}
     </div>


### PR DESCRIPTION
I think we can remove the `key` prop from the `BlogPost` component in the `BlogPostsCell` code sample at line 218. 

I'm following along with the repo supplied at the start of Tutorial2, and the `key` prop isn't passed [there](https://github.com/redwoodjs/redwood-tutorial/blob/81372de63b850ed7bd72ec9b3005eb5a0cb5dac8/web/src/components/BlogPostsCell/BlogPostsCell.js#L26).