### PR TITLE
Fix BlogPostsCell Success test

### DIFF
--- a/TUTORIAL2.md
+++ b/TUTORIAL2.md
@@ -303,7 +303,7 @@ describe('BlogPostsCell', () => {
     render(<Success posts={posts} />)
 
     posts.forEach((post) => {
-      const truncatedBody = posts[0].body.substring(0, 10)
+      const truncatedBody = post.body.substring(0, 10)
       const regex = new RegExp(`${truncatedBody}.*?\.{3}`)
 
       expect(screen.getByText(post.title)).toBeInTheDocument()
@@ -319,7 +319,7 @@ This loops through each post in our `standard()` mock and for each one:
 <div class="code-dl">
 
 ```javascript
-const truncatedBody = posts[0].body.substring(0, 10)
+const truncatedBody = post.body.substring(0, 10)
 ```
 Create a variable `truncatedBody` containing the first 10 characters of the post body
 


### PR DESCRIPTION
Change the `posts.forEach` loop to reference the truncatedBody of each post in turn, instead of only the first post (`posts[0]`).