### PR TITLE
Fix BlogPostsCell test regex

### DIFF
--- a/TUTORIAL2.md
+++ b/TUTORIAL2.md
@@ -304,7 +304,7 @@ describe('BlogPostsCell', () => {
 
     posts.forEach((post) => {
       const truncatedBody = posts[0].body.substring(0, 10)
-      const regex = new RegExp(`${truncatedBody}.*?\.{3}`)
+      const regex = new RegExp(`${truncatedBody}.*\.{3}`)
 
       expect(screen.getByText(post.title)).toBeInTheDocument()
       expect(screen.queryByText(post.body)).not.toBeInTheDocument()
@@ -324,9 +324,9 @@ const truncatedBody = posts[0].body.substring(0, 10)
 Create a variable `truncatedBody` containing the first 10 characters of the post body
 
 ```javascript
-const regex = new RegExp(`${truncatedBody}.*?\.{3}`)
+const regex = new RegExp(`${truncatedBody}.*\.{3}`)
 ```
-Create a regular expression which contains those 10 characters followed by any characters `.*?` until it reaches three periods `\.{3}` (the ellipsis at the end of the truncated text)
+Create a regular expression which contains those 10 characters followed by any characters `.*` until it reaches three periods `\.{3}` (the ellipsis at the end of the truncated text)
 
 ```javascript
 expect(screen.getByText(post.title)).toBeInTheDocument()


### PR DESCRIPTION
I'm a regex novice, but I'm not sure the regex in the BlogPostsCell Success test needs to include the 'lazy' switch (`?`) after the star `*` here.