### PR TITLE
Docs: TypeScript docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Other documentation is pulled from various READMEs in the main [redwoodjs/redwoo
 
 This codebase is built with https://cameronjs.com and relies on plain HTML pages and Javascript with a couple helpers built in to abstract things like partials and layouts. We use https://stimulusjs.org for the few sprinkles of interactivity throughout the site.
 
-First, make sure that you are running Node 14+. If you're not sure of how to manage your node versions, see [nvm](https://github.com/nvm-sh/nvm).
+First, make sure that you are running Node 14+. If you're not sure of how to manage your node versions, see [nvm](https://github.com/nvm-sh/nvm) or [nvm-windows](https://github.com/coreybutler/nvm-windows).
 
 Then build the tutorial and doc pages (after you've installed all dependencies with `yarn install`):
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Other documentation is pulled from various READMEs in the main [redwoodjs/redwoo
 
 This codebase is built with https://cameronjs.com and relies on plain HTML pages and Javascript with a couple helpers built in to abstract things like partials and layouts. We use https://stimulusjs.org for the few sprinkles of interactivity throughout the site.
 
+First, make sure that you are running Node 14+. If you're not sure of how to manage your node versions, see [nvm](https://github.com/nvm-sh/nvm).
+
 Then build the tutorial and doc pages (after you've installed all dependencies with `yarn install`):
 
     yarn build

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -70,6 +70,6 @@ If you're adding tests, you'll want to include the types for `jest` in your `tsc
 +"types": ["jest"]
 ```
 
-Currently, these are added to `node_modules` by `@redwoodjs/core` and the above approach should just work. If this is not the case, you can `npm i -D @types/jest` in the `web` folder and they will resolve.
+Currently, these are added to `node_modules` by `@redwoodjs/core` and the above approach should just work. If this is not the case, you can `yarn add -D @types/jest` in the `web` folder and they will resolve.
 
 If you have any problems please open an issue and let us know.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,6 +1,5 @@
 # Typescript
 
-
 > TypeScript support is in development: The ability to use TypeScript is one of our main points of focus, check out our [TypeScript Project Board](https://github.com/redwoodjs/redwood/projects/2) to follow the progress.
 
 Redwood does not use the TypeScript compiler; instead, we use babel, which strips out the types before transpiling them.
@@ -12,6 +11,7 @@ Redwood does not use the TypeScript compiler; instead, we use babel, which strip
 ### API
 
 Create a `./api/tsconfig.json` file:
+
 ```json
 {
   "compilerOptions": {
@@ -25,9 +25,10 @@ Create a `./api/tsconfig.json` file:
     "paths": {
       "src/*": ["./src/*"]
     },
-    "typeRoots": ["../.redwood"]
+    "typeRoots": ["../.redwood"],
+    "types": []
   },
-  "include": ["src"],
+  "include": ["src"]
 }
 ```
 
@@ -36,6 +37,7 @@ You should now have type definitions, you can rename your files from `.js` to `.
 ### WEB
 
 Create a `./web/tsconfig.json` file:
+
 ```json
 {
   "compilerOptions": {
@@ -50,12 +52,24 @@ Create a `./web/tsconfig.json` file:
     "paths": {
       "src/*": ["./src/*"]
     },
-    "typeRoots": ["../.redwood"]
+    "typeRoots": ["../.redwood"],
+    "types": []
   },
-  "include": ["src"],
+  "include": ["src"]
 }
 ```
 
 You should now have type definitions, you can rename your files from `.js` to `.ts`, and the files that contain JSX to `.tsx`.
+
+#### Getting types for `jest` in test files
+
+If you're adding tests, you'll want to include the types for `jest` in your `tsconfig`.
+
+```diff
+-"types": []
++"types": ["jest"]
+```
+
+Currently, these are added to `node_modules` by `@redwoodjs/core` and the above approach should just work. If this is not the case, you can `npm i -D @types/jest` in the `web` folder and they will resolve.
 
 If you have any problems please open an issue and let us know.


### PR DESCRIPTION
- Add notes about minimum required node version for local dev
- Add notes about types for `jest`
- Addresses points from https://github.com/redwoodjs/redwood/issues/1400

There is an additional issue here when working with scaffolded code and the file structure, but I don't know if it is worth addressing with this PR. https://github.com/redwoodjs/redwood/issues/234#issuecomment-620906084 regarding the DirectoryName convention. TS users would just have to:
 1. add an `index.ts` to `src/components/WhateverComponent'`
 2. `export { default as default } from './WhateverComponent'`

As a side note, I didn't see any specific plan for handling this in the tracking issue: https://github.com/redwoodjs/redwood/issues/523

Thanks!