### PR TITLE
Add a step in the RBAC section to ensure the success of refetchQuery action after deletion

### DIFF
--- a/TUTORIAL2.md
+++ b/TUTORIAL2.md
@@ -2335,6 +2335,26 @@ const Comment = ({ comment }) => {
 export default Comment
 ```
 
+Don't forget to update the `CommentsQuery` we're importing from **CommentsCell** to include the `postId` field, since we are relying on it to perform the `refetchQuery` after a successful deletion.
+
+```javascript{11}
+// web/src/components/CommentsCell/CommentsCell.js
+
+import Comment from 'src/components/Comment'
+
+export const QUERY = gql`
+  query CommentsQuery($postId: Int!) {
+    comments(postId: $postId) {
+      id
+      name
+      body
+      postId
+      createdAt
+    }
+  }
+`
+```
+
 Click "Delete" (as a moderator) and the comment should be removed!
 
 Ideally we'd have both versions of this component (with and without the "Delete" button) present in Storybook so we can iterate on the design. But there's no such thing as "logging in" in Storybook and our code depends on being logged in so we can check our roles...how will that work?


### PR DESCRIPTION
1. Add a step to ensure the success of `refetchQuery` action after the deletion. (fixes #523)
    <img width="523" alt="Screenshot 2021-01-26 at 1 06 50 AM" src="https://user-images.githubusercontent.com/6315466/105739188-ccb11580-5f72-11eb-894d-c3f452d9ed2a.png">
    <img width="380" alt="Screenshot 2021-01-26 at 1 08 03 AM" src="https://user-images.githubusercontent.com/6315466/105739309-f2d6b580-5f72-11eb-913c-dfc5f90fb24d.png">
2. ~~Add `mockGraphQLQuery()` example while fixing the **BlogPost** Storybook error~~ (potentially an invalid issue)
    <img width="1280" alt="Screenshot 2021-01-26 at 12 44 57 AM" src="https://user-images.githubusercontent.com/6315466/105736643-fddc1680-5f6f-11eb-9f0f-fd5c2b7102f4.png">
    <img width="852" alt="Screenshot 2021-01-26 at 12 56 00 AM" src="https://user-images.githubusercontent.com/6315466/105737743-4516d700-5f71-11eb-8e7f-0fa09061dc9e.png">
">
