### PR TITLE
[v0.24] Updates Supabase Authentication documentation with OAuth and magiclink support

### DIFF
--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.21.0" })
+@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.23.0" })
 @@contentFor("hero",
 <div class="bg-red-100">
   <div class="lg:flex lg:items-center max-w-screen-xl mx-auto px-8 py-12 md:py-20">

--- a/code/html/logos.html
+++ b/code/html/logos.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.21.0" })
+@@layout("application", { "title": "RedwoodJS - Bringing Full-stack to the Jamstack", "version": "v0.23.0" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center pb-16">

--- a/code/html/roadmap.html
+++ b/code/html/roadmap.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "Roadmap : RedwoodJS Docs", "version": "v0.21.0" })
+@@layout("application", { "title": "Roadmap : RedwoodJS Docs", "version": "v0.23.0" })
 
 @@contentFor("aside",
   <aside class="hidden xl:block w-1/4 h-auto overflow-y-visible">

--- a/code/html/stickers-thanks.html
+++ b/code/html/stickers-thanks.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.21.0" })
+@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.23.0" })
 
 <style type="text/css">
   :root {

--- a/code/html/stickers.html
+++ b/code/html/stickers.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.21.0" })
+@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.23.0" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center">

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -450,6 +450,25 @@ You can find these values in your project's dashboard under Settings -> API.
 
 For full client docs, see: <https://supabase.io/docs/library/getting-started#reference>
 
+#### Usage
+
+Supabase supports several signin methods: 
+
+* email/password
+* passwordless via emailed magiclink
+* OAuth (such as Bitbucket, GitHub, GitLab, or Google).
+
+Depending on the credentials provided:
+
+* A user can sign up either via email or OAuth.
+* If you provide email without a password, the user will be sent a magic link.
+* The magic link's destination URL is determined by the SITE_URL config variable. To change this, you can go to Authentication -> Settings on `app.supabase.io` for your project.
+* Specifying an OAuth provider (such as Bitbucket, GitHub, GitLab, or Google) will open the browser to the relevant login page
+* Note: You must enable and configure the OAuth provider appropriately. To configure these providers, you can go to Authentication -> Settings on `app.supabase.io` for your project.
+
+For full Sign In docs, see: <https://supabase.io/docs/client/auth-signin>
+
+
 +++
 
 ### Ethereum


### PR DESCRIPTION
These updates to the Authentication docs addresses https://github.com/redwoodjs/redwood/pull/1669 and notes that Supabase authentication can be used with a passwordless magiclink, OAuth providers (ones supported by GoTrue like GitHub and Biutbucket etc), in addition to the email/password provider.