### PR TITLE
Update Self-hosting_Redwood.md

### DIFF
--- a/cookbook/Self-hosting_Redwood.md
+++ b/cookbook/Self-hosting_Redwood.md
@@ -23,11 +23,11 @@ You should have some basic knowledge of the following tools.
 
 ### Project
 
-Add Redwood's API server (in the API workspace) and PM2 (in the root) to your project.
+Add Redwood's API server (in the API workspace) and PM2 (in the root with the -W flag) to your project.
 
 ```termninal
 yarn workspace api add @redwoodjs/api-server
-yarn add -D pm2
+yarn add -D pm2 -W
 ```
 
 Create a PM2 ecosystem configuration file. For clarity, it's recommended to rename `ecosystem.config.js` to something like `pm2.config.js`.


### PR DESCRIPTION
running 
`yarn add -D pm2`
gives the errror:
`error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).`