### PR TITLE
Update & Fix links in TUTORIAL.md

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2892,9 +2892,9 @@ As an anonymous Twitter user once mused: "If you enjoy switching between feeling
 
 ### What's Next?
 
-If you're ready for even more Redwood, head to the [Tutorial Part 2](/tutorial2)! We'll look at Storybook and Jest and build a new feature for the blog: comments. Storybook introduces a new way to build components. We'll also add tests and run them with Jest to make sure things keep working as we expect.
+If you're ready for even more Redwood, head to the [Tutorial Part 2](/TUTORIAL2.md)! We'll look at Storybook and Jest and build a new feature for the blog: comments. Storybook introduces a new way to build components. We'll also add tests and run them with Jest to make sure things keep working as we expect.
 
-Want to add some more features to your app? Check out some of our Cookbook recipies like [calling to a third party API](/cookbook/using-a-third-party-api) and [deploying an app without an API at all](/cookbook/disable-api-database). Have you grown out of SQLite and want to [install Postgres locally](/docs/local-postgres-setup)? We've also got lots of [guides](/docs/introduction) for more info on Redwood's internals.
+Want to add some more features to your app? Check out some of our Cookbook recipies like [calling to a third party API](/cookbook/Third_Party_API.md) and [deploying an app without an API at all](/cookbook/No_API.md). Have you grown out of SQLite and want to [install Postgres locally](/docs/localPostgresSetup.md)? We've also got lots of [guides](/docs/quick-start.md) for more info on Redwood's internals.
 
 ### Roadmap
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2892,9 +2892,9 @@ As an anonymous Twitter user once mused: "If you enjoy switching between feeling
 
 ### What's Next?
 
-If you're ready for even more Redwood, head to the [Tutorial Part 2](/TUTORIAL2.md)! We'll look at Storybook and Jest and build a new feature for the blog: comments. Storybook introduces a new way to build components. We'll also add tests and run them with Jest to make sure things keep working as we expect.
+If you're ready for even more Redwood, head to the [Tutorial Part 2](https://github.com/redwoodjs/redwoodjs.com/blob/main/TUTORIAL2.md)! We'll look at Storybook and Jest and build a new feature for the blog: comments. Storybook introduces a new way to build components. We'll also add tests and run them with Jest to make sure things keep working as we expect.
 
-Want to add some more features to your app? Check out some of our Cookbook recipies like [calling to a third party API](/cookbook/Third_Party_API.md) and [deploying an app without an API at all](/cookbook/No_API.md). Have you grown out of SQLite and want to [install Postgres locally](/docs/localPostgresSetup.md)? We've also got lots of [guides](/docs/quick-start.md) for more info on Redwood's internals.
+Want to add some more features to your app? Check out some of our Cookbook recipies like [calling to a third party API](https://github.com/redwoodjs/redwoodjs.com/blob/main/cookbook/Third_Party_API.md) and [deploying an app without an API at all](https://github.com/redwoodjs/redwoodjs.com/blob/main/cookbook/No_API.md). Have you grown out of SQLite and want to [install Postgres locally](https://github.com/redwoodjs/redwoodjs.com/blob/main/docs/localPostgresSetup.md)? We've also got lots of [guides](https://github.com/redwoodjs/redwood/blob/main/README.md) for more info on Redwood's internals.
 
 ### Roadmap
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Love Redwood and want to get involved? You’re in the right place and in good company! As of this writing, there are over [100 individuals](https://github.com/redwoodjs/redwood/blob/main/README.md#contributors) who have helped make Redwood awesome by contributing code and documentation. This doesn't include all those who participate in the vibrant, helpful, and encouraging Forums and Discord, which are both great places to get started if you have any questions.
+Love Redwood and want to get involved? You’re in the right place and in good company! As of this writing, there are more than [170 contributors](https://github.com/redwoodjs/redwood/blob/main/README.md#contributors) who have helped make Redwood awesome by contributing code and documentation. This doesn't include all those who participate in the vibrant, helpful, and encouraging Forums and Discord, which are both great places to get started if you have any questions.
 
 There are several ways you can contribute to Redwood:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,7 +23,7 @@ What you want to do not on the roadmap? Well, still go for it! We love spikes an
 
 |Package|Description|
 |:-|:-|
-|[`@redwoodjs/api-server`](https://github.com/redwoodjs/redwood/blob/main/packages/api-server/README.md)|Run a Redwood App using an Express server alternative to a serverless API|
+|[`@redwoodjs/api-server`](https://github.com/redwoodjs/redwood/blob/main/packages/api-server/README.md)|Run a Redwood app using Express server (alternative to serverless API)|
 |[`@redwoodjs/api`](https://github.com/redwoodjs/redwood/blob/main/packages/api/README.md)|Exposes functions to build the GraphQL API and provides services with `context`|
 |[`@redwoodjs/auth`](https://github.com/redwoodjs/redwood/blob/main/packages/auth/README.md#contributing)|A lightweight wrapper around popular SPA authentication libraries|
 |[`@redwoodjs/cli`](https://github.com/redwoodjs/redwood/blob/main/packages/cli/README.md)|All the commands for Redwood's built-in CLI|

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,6 +23,7 @@ What you want to do not on the roadmap? Well, still go for it! We love spikes an
 
 |Package|Description|
 |:-|:-|
+|[`@redwoodjs/api-server`](https://github.com/redwoodjs/redwood/blob/main/packages/api-server/README.md)|Run a Redwood App using an Express server alternative to a serverless API|
 |[`@redwoodjs/api`](https://github.com/redwoodjs/redwood/blob/main/packages/api/README.md)|Exposes functions to build the GraphQL API and provides services with `context`|
 |[`@redwoodjs/auth`](https://github.com/redwoodjs/redwood/blob/main/packages/auth/README.md#contributing)|A lightweight wrapper around popular SPA authentication libraries|
 |[`@redwoodjs/cli`](https://github.com/redwoodjs/redwood/blob/main/packages/cli/README.md)|All the commands for Redwood's built-in CLI|


### PR DESCRIPTION
Hi this PR fixes #541 

Link updating:

* Tutorial Part 2
* calling to a third party API
* deploying an app without an API at all
* install Postgres locally?
* guides

in What's Next? -> TUTORIAL.md

I hope this be good.

Thanks