### PR TITLE
Modify self-hosting build command for prisma deploy

### DIFF
--- a/cookbook/Self-hosting_Redwood.md
+++ b/cookbook/Self-hosting_Redwood.md
@@ -93,7 +93,7 @@ const user = 'deploy' // Server user
 const path = `/home/${user}/${name}` // Path on the server to deploy to
 const host = 'example.com' // Server hostname
 const port = 8911 // Port to use locally on the server
-const build = 'yarn install && yarn rw build && yarn rw db up && yarn rw db seed' // Build commands
+const build = `yarn install && yarn rw build && yarn rw prisma deploy`
 
 module.exports = {
   apps: [
@@ -125,6 +125,8 @@ module.exports = {
   },
 }
 ```
+
+> Note: if you need to seed tour production database during your first deployment, you'll need to add `&& yarn rw prisma db seed` to the end of your build command. But don't forget to remove it prior to subsquent deploys!
 
 > Caveat: the API seems to only work in fork mode in PM2, not [cluster mode](https://pm2.keymetrics.io/docs/usage/cluster-mode/)
 

--- a/cookbook/Self-hosting_Redwood.md
+++ b/cookbook/Self-hosting_Redwood.md
@@ -126,7 +126,7 @@ module.exports = {
 }
 ```
 
-> Note: if you need to seed tour production database during your first deployment, you'll need to add `&& yarn rw prisma db seed` to the end of your build command. But don't forget to remove it prior to subsquent deploys!
+> Note: if you need to seed tour production database during your first deployment, you'll need to add `&& yarn rw prisma db seed` to the end of your build command. But don't forget to remove it prior to subsequent deploys!
 
 > Caveat: the API seems to only work in fork mode in PM2, not [cluster mode](https://pm2.keymetrics.io/docs/usage/cluster-mode/)
 


### PR DESCRIPTION
This PR changes the build command example for serverful (pm2) deployment to:

* use prisma deploy
* remove seeding
* and note is need to seed on first deployment but to remove for subsequent ones