### PR TITLE
Add missing line breaks

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -416,6 +416,8 @@ Deploy to AWS using the selected provider
 yarn redwood deploy aws [provider]
 ```
 
+<br/>
+
 | Options & Arguments  | Description                              |
 | :------------------- | :--------------------------------------- |
 | `provider`           | AWS Deploy provider to configure [choices: "serverless"] [default: "serverless"] |
@@ -428,6 +430,8 @@ Build command for Netlify deploy
 ```
 yarn redwood deploy netlify [provider]
 ```
+
+<br/>
 
 | Options  | Description                              |
 | :------------------- | :--------------------------------------- |
@@ -448,6 +452,8 @@ Build command for Vercel deploy
 ```
 yarn redwood deploy vercel [provider]
 ```
+
+<br/>
 
 | Options  | Description                              |
 | :------------------- | :--------------------------------------- |


### PR DESCRIPTION
This PR just adds a few missing line breaks back to the CLI Commands doc (between the code block and the table):

![image](https://user-images.githubusercontent.com/32992335/107839447-cb4c5f00-6d60-11eb-831d-2b512e260bb1.png)
