### PR TITLE
Tutorial: Match current `prisma migrate dev` behavior

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -535,9 +535,7 @@ That was simple. Now we'll want to snapshot this as a migration:
 >
 > From now on we'll use the shorter `rw` alias instead of the full `redwood` argument.
 
-You'll be prompted to give this migration a name. Something that describes what it does is ideal, so how about "create posts" (without the quotes, of course). This is for your own benefit—Redwood doesn't care about the migration's name, it's just a reference when looking through old migrations and trying to find when you created or modified something specific.
-
-After the command completes you'll see a new subdirectory created under `api/db/migrations` that has a timestamp and the name you gave the migration. It will contain a single file named `migration.sql` that contains the SQL necessary to bring the database structure up-to-date with whatever `schema.prisma` looked like at the time the migration was created. So you have a single `schema.prisma` file that describes what the database structure should look like right *now* and the migrations trace the history of the changes that took place to get to the current state. It's kind of like version control for your database structure, which can be pretty handy.
+After the command completes you'll see a new subdirectory created under `api/db/migrations` with the current time as its name. It will contain a single file named `migration.sql` that contains the SQL necessary to bring the database structure up-to-date with whatever `schema.prisma` looked like at the time the migration was created. So you have a single `schema.prisma` file that describes what the database structure should look like right *now* and the migrations trace the history of the changes that took place to get to the current state. It's kind of like version control for your database structure, which can be pretty handy.
 
 In addition to creating the migration file, the above command will also execute the SQL against the database, which "applies" the migration. The final result is a new database table called `Post` with the fields we defined above.
 


### PR DESCRIPTION
`yarn rw prisma migrate dev` never asks for a name for the migration.

This updates the tutorial to match the current behavior to not confuse any readers. When the command asks for a name again, this commit can be reverted.