### PR TITLE
Add "WIP" copy to the docs that need it

### DIFF
--- a/docs/assetsAndFiles.md
+++ b/docs/assetsAndFiles.md
@@ -1,5 +1,13 @@
 # Assets and Files
 
+> ⚠ **Work in Progress** ⚠️
+>
+> There's more to document here. In the meantime, you can check our [community forum](https://community.redwoodjs.com/search?q=assets%20and%20files) for answers.
+>
+> Want to contribute? Redwood welcomes contributions and loves helping people become contributors.
+> You can edit this doc [here](https://github.com/redwoodjs/redwoodjs.com/blob/main/docs/assetsAndFiles.md).
+> If you have any questions, just ask for help! We're active on the [forums](https://community.redwoodjs.com/c/contributing/9) and on [discord](https://discord.com/channels/679514959968993311/747258086569541703).
+
 There are two methods for adding assets to a Redwood app: 
 
 i)  Webpack imports and 

--- a/docs/builds.md
+++ b/docs/builds.md
@@ -1,5 +1,14 @@
 # Builds
 
+> ⚠ **Work in Progress** ⚠️
+>
+> There's more to document here. In the meantime, you can check our [community forum](https://community.redwoodjs.com/search?q=yarn%20rw%20build) for answers.
+>
+> Want to contribute? Redwood welcomes contributions and loves helping people become contributors.
+> You can edit this doc [here](https://github.com/redwoodjs/redwoodjs.com/blob/main/docs/builds.md). 
+> If you have any questions, just ask for help! We're active on the [forums](https://community.redwoodjs.com/c/contributing/9) and on [discord](https://discord.com/channels/679514959968993311/747258086569541703).
+
+
 ## API
 
 The api side of Redwood is transpiled by Babel into the `./api/dist` folder.

--- a/docs/connectionPooling.md
+++ b/docs/connectionPooling.md
@@ -1,5 +1,13 @@
 # Connection Pooling
 
+> ⚠ **Work in Progress** ⚠️
+>
+> There's more to document here. In the meantime, you can check our [community forum](https://community.redwoodjs.com/search?q=connection%20pooling) for answers.
+>
+> Want to contribute? Redwood welcomes contributions and loves helping people become contributors.
+> You can edit this doc [here](https://github.com/redwoodjs/redwoodjs.com/blob/main/docs/connectionPooling.md).
+> If you have any questions, just ask for help! We're active on the [forums](https://community.redwoodjs.com/c/contributing/9) and on [discord](https://discord.com/channels/679514959968993311/747258086569541703).
+
 Production Redwood apps should enable connection pooling in order to properly scale with your Serverless functions.
 
 ## Heroku

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,8 +1,14 @@
 # Typescript
 
-> TypeScript support is in development: The ability to use TypeScript is one of our main points of focus, check out our [TypeScript Project Board](https://github.com/redwoodjs/redwood/projects/2) to follow the progress.
+> ⚠ **Work in Progress** ⚠️
+>
+> TypeScript support is in development. It's one of our main priorities. To follow our progress, check the [TypeScript Project Board](https://github.com/redwoodjs/redwood/projects/2).
+>
+> Want to contribute? Redwood welcomes contributions and loves helping people become contributors.
+> You can edit this doc [here](https://github.com/redwoodjs/redwoodjs.com/blob/main/docs/typescript.md).
+> If you have any questions, just ask for help! We're active on the [forums](https://community.redwoodjs.com/c/contributing/9) and on [discord](https://discord.com/channels/679514959968993311/747258086569541703).
 
-Redwood does not use the TypeScript compiler; instead, we use babel, which strips out the types before transpiling them.
+Redwood doesn't use the TypeScript compiler; instead, we use Babel, which strips out the types before transpiling.
 
 ## Manual Setup
 
@@ -32,7 +38,7 @@ Create a `./api/tsconfig.json` file:
 }
 ```
 
-You should now have type definitions, you can rename your files from `.js` to `.ts`
+You should now have type definitions&mdash;you can rename your files from `.js` to `.ts`
 
 ### WEB
 
@@ -59,7 +65,7 @@ Create a `./web/tsconfig.json` file:
 }
 ```
 
-You should now have type definitions, you can rename your files from `.js` to `.ts`, and the files that contain JSX to `.tsx`.
+You should now have type definitions&mdash;you can rename your files from `.js` to `.ts`, and the files that contain JSX to `.tsx`.
 
 #### Getting types for `jest` in test files
 
@@ -70,6 +76,6 @@ If you're adding tests, you'll want to include the types for `jest` in your `tsc
 +"types": ["jest"]
 ```
 
-Currently, these are added to `node_modules` by `@redwoodjs/core` and the above approach should just work. If this is not the case, you can `yarn add -D @types/jest` in the `web` folder and they will resolve.
+Currently, these are added to `node_modules` by `@redwoodjs/core` and the above approach should just work. If this isn't the case, you can `yarn add -D @types/jest` in the `web` folder.
 
-If you have any problems please open an issue and let us know.
+If you have any problems, please open an issue and let us know!


### PR DESCRIPTION
There's a few docs that need some work and in addition to making some kind of master tracking issue / project board to coordinate efforts, we might as well say upfront in the doc that we're working on things. Just mirroring the global effort locally.