### PR TITLE
Correct dataMigrate commands to use prisma migrate

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -141,7 +141,7 @@ yarn rw dataMigrate <command>
 ### install
 
 - Appends a `DataMigration` model to `schema.prisma` for tracking which data migrations have already run.
-- Creates a DB migration using `yarn rw db save 'create data migrations`.
+- Creates a DB migration using `yarn rw prisma migrate dev --create-only 'create data migrations`.
 - Creates `api/db/dataMigrations` directory to contain data migration scripts
 
 ```terminal

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -141,7 +141,7 @@ yarn rw dataMigrate <command>
 ### install
 
 - Appends a `DataMigration` model to `schema.prisma` for tracking which data migrations have already run.
-- Creates a DB migration using `yarn rw prisma migrate dev --create-only 'create data migrations`.
+- Creates a DB migration using `yarn rw prisma migrate dev --create-only create_data_migrations`.
 - Creates `api/db/dataMigrations` directory to contain data migration scripts
 
 ```terminal

--- a/docs/dataMigrations.md
+++ b/docs/dataMigrations.md
@@ -36,9 +36,9 @@ model DataMigration {
 }
 ```
 
-The install script also ran `yarn rw db save` automatically so you have a DB migration ready to go. You just need to run the `up` command to apply it:
+The install script also ran `yarn rw prisma migrate dev --create-only` automatically so you have a DB migration ready to go. You just need to run the `prisma migrate dev` command to apply it:
 
-    yarn rw db up
+    yarn rw prisma migrate dev
 
 ## Creating a New Data Migration
 


### PR DESCRIPTION
The docs for dataMigrate still referenced the old `db save` and `db up` migration commands.

![image](https://user-images.githubusercontent.com/1051633/109076664-ee640080-76c8-11eb-9cd8-604560a5b96f.png)

This PR corrects this and notes how to use the `yarn rw prisma migrate dev` command.