### PR TITLE
Add "Custom Index" doc

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1388,26 +1388,12 @@ yarn rw setup <command>
 
 | Commands   | Description                                                            |
 | :--------- | :--------------------------------------------------------------------- |
-| `auth`     | Setup  auth configuration for a provider                               |
+| `auth`     | Setup auth configuration for a provider                               |
+| `custom-entry`     | Setup a custom entry.js file, so you can customise how Redwood web is mounted in your browser |
 | `deploy`   | Setup a deployment configuration for  a provider                       |
 | `i18n`     | Setup i18n                                                             |
 | `tailwind` | Setup tailwindcss and PostCSS                                          |
 | `webpack`  | Setup webpack config file in your project so you can add custom config |
-
-### setup deploy (config)
-
-Setup a deployment configuration.
-
-```
-yarn rw setup deploy <provider>
-```
-
-Creates provider-specific code and configuration for deployment
-
-| Arguments & Options | Description                                                                        |
-| :------------------ | :--------------------------------------------------------------------------------- |
-| `provider`          | Deploy provider to configure. Choices are `netlify`, `vercel`, or `aws-serverless` |
-| `--force, -f`       | Overwrite existing configuration [default: false]         |
 
 ### setup auth
 
@@ -1427,6 +1413,39 @@ You can get authentication out-of-the-box with generators. Right now we support 
 **Usage**
 
 See [Authentication](https://redwoodjs.com/docs/authentication).
+
+### setup custom-index
+
+Setup an `index.js` file so you can customize how Redwood web is mounted in your browser.
+
+```
+yarn rw setup custom-index
+```
+
+Redwood automatically mounts your `<App />` to the DOM, but if you want to customize how that happens, you can use this setup command to generate a file where you can do that in.
+
+| Arguments & Options | Description                                                                                      |
+| :------------------ | :----------------------------------------------------------------------------------------------- |
+| `--force, -f`       | Overwrite existing files                                                                         |
+
+**Usage**
+
+See [Custom Entry](https://redwoodjs.com/docs/custom-entry).
+
+### setup deploy (config)
+
+Setup a deployment configuration.
+
+```
+yarn rw setup deploy <provider>
+```
+
+Creates provider-specific code and configuration for deployment.
+
+| Arguments & Options | Description                                                                        |
+| :------------------ | :--------------------------------------------------------------------------------- |
+| `provider`          | Deploy provider to configure. Choices are `netlify`, `vercel`, or `aws-serverless` |
+| `--force, -f`       | Overwrite existing configuration [default: false]         |
 
 ## storybook
 

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1416,7 +1416,7 @@ See [Authentication](https://redwoodjs.com/docs/authentication).
 
 ### setup custom-index
 
-Setup an `index.js` file so you can customize how Redwood web is mounted in your browser.
+Setup an `index.js` file in `web/src` so you can customize how your Redwood App mounts to the DOM.
 
 ```
 yarn rw setup custom-index
@@ -1430,7 +1430,7 @@ Redwood automatically mounts your `<App />` to the DOM, but if you want to custo
 
 **Usage**
 
-See [Custom Entry](https://redwoodjs.com/docs/custom-entry).
+See [Custom Index](https://redwoodjs.com/docs/custom-index).
 
 ### setup deploy (config)
 

--- a/docs/customIndex.md
+++ b/docs/customIndex.md
@@ -1,0 +1,49 @@
+# Custom Index
+
+You might've noticed that there's no call to `ReactDOM.render` anywhere in your Redwood App (`v0.26` and greater). That's because Redwood automatically mounts your `<App />` in `web/src/App.js` to the DOM. But if you need to customize how this happens, you can provide a file called `index.js` in `web/src` and Redwood will use that instead.
+
+To make this easy to do, there's a setup command that'll give you the file you need where you need it: 
+
+```
+yarn rw setup custom-index
+```
+
+This generates a file named `index.js` in `web/src` that looks like this:
+
+```js
+// web/src/index.js
+
+import ReactDOM from 'react-dom'
+
+import App from './App'
+/**
+ * When `#redwood-app` isn't empty then it's very likely that you're using
+ * prerendering. So React attaches event listeners to the existing markup
+ * rather than replacing it.
+ * https://reactjs.org/docs/react-dom.html#hydrate
+ */
+const rootElement = document.getElementById('redwood-app')
+
+if (rootElement.hasChildNodes()) {
+  ReactDOM.hydrate(<App />, rootElement)
+} else {
+  ReactDOM.render(<App />, rootElement)
+```
+
+<!-- TODO: change link? -->
+This is actually the same file Redwood uses [internally](https://github.com/redwoodjs/redwood/blob/main/packages/web/src/entry/index.js). So even if you don't customize anything any further than this, things will still work the way the should! 
+
+<!-- ## When would I want a custom entry?
+
+The reason for a custom entry is usually related to tooling. For example, consider something like [@axe-core/react](https://www.npmjs.com/package/@axe-core/react)&mdash;it uses `React` and `ReactDOM` to console a11y violations in realtime. 
+
+The code block it requires you to add is:
+
+```js
+if (process.env.NODE_ENV === 'development') {
+  const axe = require('@axe-core/react');
+  axe(React, ReactDOM, 1000);
+}
+```
+
+Since it uses `ReactDOM`, the best place for this is in `web/src/entry.js`. -->

--- a/lib/build.js
+++ b/lib/build.js
@@ -73,6 +73,10 @@ const SECTIONS = [
       },
       {
         pageBreakAtHeadingDepth: [1],
+        url: './docs/customIndex.md',
+      },
+      {
+        pageBreakAtHeadingDepth: [1],
         url: './docs/dataMigrations.md',
       },
       {


### PR DESCRIPTION
> https://deploy-preview-589--redwoodjs.netlify.app/docs/custom-index

Adds a doc on providing a custom index.js for hydrating/mounting to the dom. As of v0.26, Redwood mounts `App.js`'s default export. There's cases where you might want more control over this.