### PR TITLE
fix: add node_modules/@types to typeRoots in typescript docs

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -31,7 +31,7 @@ Create a `./api/tsconfig.json` file:
     "paths": {
       "src/*": ["./src/*"]
     },
-    "typeRoots": ["../.redwood"],
+    "typeRoots": ["../node_modules/@types", "../.redwood"],
     "types": []
   },
   "include": ["src"]
@@ -58,7 +58,7 @@ Create a `./web/tsconfig.json` file:
     "paths": {
       "src/*": ["./src/*"]
     },
-    "typeRoots": ["../.redwood"],
+    "typeRoots": ["../node_modules/@types", "../.redwood"],
     "types": []
   },
   "include": ["src", "../.redwood/globals"]


### PR DESCRIPTION
This fixes [#1820](https://github.com/redwoodjs/redwood/issues/1820)

Should apply for both web and api sides.