### PR TITLE
add more Webpack Dev Server info to 2 related docs

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -363,13 +363,13 @@ yarn redwood dev [side..]
 | Argument           | Description                                                                                                                          |
 | :----------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
 | `side`             | Which dev server(s) to start. Choices are `api` and `web`. Defaults to `api` and `web`                                               |
-| `--forward, --fwd` | String of one or more [Webpack DevServer](https://webpack.js.org/configuration/dev-server/) config options. See example usage below. |
+| `--forward, --fwd` | String of one or more Webpack Dev Server config options. See example usage below. See the [Redwood Webpack Doc](https://redwoodjs.com/docs/webpack-configuration#webpack-dev-server) for more details and examples. |
 
 **Usage**
 
 If you're only working on your sdl and services, you can run just the api server to get GraphQL Playground on port 8911:
 
-```plaintext{10}
+```bash
 ~/redwood-app$ yarn rw dev api
 yarn run v1.22.4
 $ /redwood-app/node_modules/.bin/rw dev api
@@ -382,11 +382,18 @@ $ /redwood-app/node_modules/.bin/dev-server
 15:04:51 api | ► http://localhost:8911/graphql/
 ```
 
-Using `--forward` (alias `--fwd`), you can pass one or more Webpack DevServer config options. The following will run the dev server, set the port to `1234`, and disable automatic browser opening.
+Using `--forward` (alias `--fwd`), you can pass one or more Webpack Dev Server [config options](https://webpack.js.org/configuration/dev-server/). The following will run the dev server, set the port to `1234`, and disable automatic browser opening.
 
-```plaintext{10}
+```bash
 ~/redwood-app$ yarn rw dev --fwd="--port=1234 --open=false"
 ```
+
+You may need to access your dev application from a different host. To resolve the “Invalid Host Header” message, run the following:
+```bash
+~/redwood-app$ yarn rw dev --fwd="--disable-host-check"
+```
+
+For the full list of Webpack Dev Server settings, see [this documentation](https://webpack.js.org/configuration/dev-server/).
 
 ## deploy
 

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -388,7 +388,7 @@ Using `--forward` (alias `--fwd`), you can pass one or more Webpack Dev Server [
 ~/redwood-app$ yarn rw dev --fwd="--port=1234 --open=false"
 ```
 
-You may need to access your dev application from a different host. To resolve the “Invalid Host Header” message, run the following:
+You may need to access your dev application from a different host, like your mobile device. To resolve the “Invalid Host Header” message, run the following:
 ```bash
 ~/redwood-app$ yarn rw dev --fwd="--disable-host-check"
 ```

--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -252,7 +252,7 @@ yarn add -D sass-loader sass
 ```
 
 ## Webpack Dev Server
-Redwood is using [Webpack Dev Server](https://webpack.js.org/configuration/dev-server/) for local development. When you run `yarn rw dev`, things like [Web Port](https://webpack.js.org/configuration/dev-server/#devserverport) and [API Proxy Path](https://webpack.js.org/configuration/dev-server/#devserverproxy) are used for Dev Server settings. You can see all the settings used for Redwood dev here [webpack.development.js#L12-L32](https://github.com/redwoodjs/redwood/blob/49c3afecc210709641dd340b974c86251ed207dc/packages/core/config/webpack.development.js#L12-L32)
+Redwood uses [Webpack Dev Server](https://webpack.js.org/configuration/dev-server/) for local development. When you run `yarn rw dev`, toml keys in your `redwood.toml`'s `[web]` table, like `port` and `apiProxyPath`, are used as Dev Server settings, in this case, [devServer.port](https://webpack.js.org/configuration/dev-server/#devserverport) and [devServer.proxy](https://webpack.js.org/configuration/dev-server/#devserverproxy) respectively. You can see all the settings used for Redwood dev in [webpack.development.js#L12-L32](https://github.com/redwoodjs/redwood/blob/49c3afecc210709641dd340b974c86251ed207dc/packages/core/config/webpack.development.js#L12-L32)
 
 ### Pass settings with `--forward`
 While it's possible to override Dev Server config with a file, it's often simpler to pass options with the `yarn rw dev` command using the `--forward` flag. See the [Redwood CLI Doc](https://redwoodjs.com/docs/cli-commands#dev) for help and examples.

--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -262,7 +262,7 @@ While it's possible to override Dev Server config with a file, it's often simple
 #### Example: Set Port and Disable Browser Opening
 You can override `redwood.toml` settings:
 ```bash
-yarn rw dev --fwd="--port=1234 --open=false"
+yarn rw dev --forward="--port=1234 --open=false"
 ```
 
 This will run your application's Web client on port `1234` and disable automatic browser window openning. 

--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -252,7 +252,7 @@ yarn add -D sass-loader sass
 ```
 
 ## Webpack Dev Server
-Redwood uses [Webpack Dev Server](https://webpack.js.org/configuration/dev-server/) for local development. When you run `yarn rw dev`, toml keys in your `redwood.toml`'s `[web]` table, like `port` and `apiProxyPath`, are used as Dev Server settings, in this case, [devServer.port](https://webpack.js.org/configuration/dev-server/#devserverport) and [devServer.proxy](https://webpack.js.org/configuration/dev-server/#devserverproxy) respectively. You can see all the settings used for Redwood dev in [webpack.development.js#L12-L32](https://github.com/redwoodjs/redwood/blob/49c3afecc210709641dd340b974c86251ed207dc/packages/core/config/webpack.development.js#L12-L32)
+Redwood uses [Webpack Dev Server](https://webpack.js.org/configuration/dev-server/) for local development. When you run `yarn rw dev`, TOML keys in your `redwood.toml`'s `[web]` table, like `port` and `apiProxyPath`, are used as Dev Server settings, in this case, [devServer.port](https://webpack.js.org/configuration/dev-server/#devserverport) and [devServer.proxy](https://webpack.js.org/configuration/dev-server/#devserverproxy) respectively. You can see all the settings used for Redwood dev in [webpack.development.js#L12-L32](https://github.com/redwoodjs/redwood/blob/49c3afecc210709641dd340b974c86251ed207dc/packages/core/config/webpack.development.js#L12-L32)
 
 ### Pass settings with `--forward`
 While it's possible to override Dev Server config with a file, it's often simpler to pass options with the `yarn rw dev` command using the `--forward` flag. See the [Redwood CLI Doc](https://redwoodjs.com/docs/cli-commands#dev) for help and examples.

--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -255,7 +255,7 @@ yarn add -D sass-loader sass
 Redwood is using [Webpack Dev Server](https://webpack.js.org/configuration/dev-server/) for local development. When you run `yarn rw dev`, things like [Web Port](https://webpack.js.org/configuration/dev-server/#devserverport) and [API Proxy Path](https://webpack.js.org/configuration/dev-server/#devserverproxy) are used for Dev Server settings. You can see all the settings used for Redwood dev here [webpack.development.js#L12-L32](https://github.com/redwoodjs/redwood/blob/49c3afecc210709641dd340b974c86251ed207dc/packages/core/config/webpack.development.js#L12-L32)
 
 ### Pass settings with `--forward`
-It's possible to override Dev Server config with a file. However, it's often simpler to pass the option with the `yarn rw dev` command using the `--forward` flag. See the [Redwood CLI Doc](https://redwoodjs.com/docs/cli-commands#dev) for Dev command help and examples.
+While it's possible to override Dev Server config with a file, it's often simpler to pass options with the `yarn rw dev` command using the `--forward` flag. See the [Redwood CLI Doc](https://redwoodjs.com/docs/cli-commands#dev) for help and examples.
 
 > For the full list of Webpack Dev Server options, [see this document](https://webpack.js.org/configuration/dev-server/).
 
@@ -274,4 +274,3 @@ yarn rw dev --fwd="--disable-host-check --host 0.0.0.0 --public example.company.
 ```
 
 This runs the application and forwards to `example.company.com`.
-

--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -270,7 +270,7 @@ This will run your application's Web client on port `1234` and disable automatic
 #### Example: Allow External Host Access
 If you're running Redwood in dev mode and try to test your application from an external source (i.e. outside your network), you'll get “Invalid Host Header”.  To enable this workflow, you can run the following:
 ```bash
-yarn rw dev --fwd="--disable-host-check --host 0.0.0.0 --public example.company.com"
+yarn rw dev --forward="--disable-host-check --host 0.0.0.0 --public example.company.com"
 ```
 
 This runs the application and forwards to `example.company.com`.

--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -250,3 +250,28 @@ Support for Sass is already configured, so all you have to do is install the dev
 cd web
 yarn add -D sass-loader sass
 ```
+
+## Webpack Dev Server
+Redwood is using [Webpack Dev Server](https://webpack.js.org/configuration/dev-server/) for local development. When you run `yarn rw dev`, things like [Web Port](https://webpack.js.org/configuration/dev-server/#devserverport) and [API Proxy Path](https://webpack.js.org/configuration/dev-server/#devserverproxy) are used for Dev Server settings. You can see all the settings used for Redwood dev here [webpack.development.js#L12-L32](https://github.com/redwoodjs/redwood/blob/49c3afecc210709641dd340b974c86251ed207dc/packages/core/config/webpack.development.js#L12-L32)
+
+### Pass settings with `--forward`
+It's possible to override Dev Server config with a file. However, it's often simpler to pass the option with the `yarn rw dev` command using the `--forward` flag. See the [Redwood CLI Doc](https://redwoodjs.com/docs/cli-commands#dev) for Dev command help and examples.
+
+> For the full list of Webpack Dev Server options, [see this document](https://webpack.js.org/configuration/dev-server/).
+
+#### Example: Set Port and Disable Browser Opening
+You can override `redwood.toml` settings:
+```bash
+yarn rw dev --fwd="--port=1234 --open=false"
+```
+
+This will run your application's Web client on port `1234` and disable automatic browser window openning. 
+
+#### Example: Allow External Host Access
+If you are runing Redwood in dev mode and would like to test your application from an external source (outside your network), you will get “Invalid Host Header”.  To enable this process, you can run the following:
+```bash
+yarn rw dev --fwd="--disable-host-check --host 0.0.0.0 --public example.company.com"
+```
+
+This runs the application and forwards to `example.company.com`.
+

--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -268,7 +268,7 @@ yarn rw dev --forward="--port=1234 --open=false"
 This will run your application's Web client on port `1234` and disable automatic browser window openning. 
 
 #### Example: Allow External Host Access
-If you are runing Redwood in dev mode and would like to test your application from an external source (outside your network), you will get “Invalid Host Header”.  To enable this process, you can run the following:
+If you're running Redwood in dev mode and try to test your application from an external source (i.e. outside your network), you'll get “Invalid Host Header”.  To enable this workflow, you can run the following:
 ```bash
 yarn rw dev --fwd="--disable-host-check --host 0.0.0.0 --public example.company.com"
 ```


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/534

Passing advanced Dev Server settings is still confusing to some people. This adds a section, with examples, to the Webpack doc. And it adds another example, plus link to Webpack Doc, to the corresponding CLI Doc section for Dev command.