### PR TITLE
bump requirement to node.js >=14

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -48,7 +48,7 @@ yarn redwood upgrade
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=12"
+- node: ">=14"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:


### PR DESCRIPTION
We bumped the requirement in the v0.27.0 release.