### PR TITLE
Add info + instructions to contribute to Tutorials via learn repo

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,0 +1,11 @@
+## Tutorial Contributions (and Translators) are Welcome!
+To support translations, the Redwood Tutorials have been moved to the `learn.redwoodjs.com` Repo:
+- **Tutorial Part 1:** [learn.redwoodjs.com/docs/tutorial/](https://github.com/redwoodjs/learn.redwoodjs.com/tree/main/docs/tutorial)
+- **Tutorial Part 2:** [learn.redwoodjs.com/docs/tutorial2/](https://github.com/redwoodjs/learn.redwoodjs.com/tree/main/docs/tutorial2)
+
+Instructions for the translation workflow and contributing are here:
+- [learn.redwoodjs.com/README.md](https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README.md)
+
+
+## Translation Project Lead
+For more information and to learn how you can help contribute and translate, please contact Core Team member [@clairefro](https://github.com/clairefro)

--- a/TUTORIAL2.md
+++ b/TUTORIAL2.md
@@ -1,0 +1,11 @@
+## Tutorial Contributions (and Translators) are Welcome!
+To support translations, the Redwood Tutorials have been moved to the `learn.redwoodjs.com` Repo:
+- **Tutorial Part 1:** [learn.redwoodjs.com/docs/tutorial/](https://github.com/redwoodjs/learn.redwoodjs.com/tree/main/docs/tutorial)
+- **Tutorial Part 2:** [learn.redwoodjs.com/docs/tutorial2/](https://github.com/redwoodjs/learn.redwoodjs.com/tree/main/docs/tutorial2)
+
+Instructions for the translation workflow and contributing are here:
+- [learn.redwoodjs.com/README.md](https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README.md)
+
+
+## Translation Project Lead
+For more information and to learn how you can help contribute and translate, please contact Core Team member [@clairefro](https://github.com/clairefro)


### PR DESCRIPTION
@cannikin @clairefro In the past when we've moved docs around, Dom and I would leave a "redirect message" to point people to the location of the new doc. I've re-added both Tutorial.md and Tutorial2.md with info + direction to the respective directories in the lean.rwjs.com repo.

I started with one file, Tutorials.md, but then realized people might be following permalinks to the previously existing files themselves. Thus, the 2 files with identical content.

Thoughts/suggestions about what's most helpful now regarding the two files and content? I imagine we can remove these altogether in the future — just a temporary "helper".