### PR TITLE
Provide more search results

### DIFF
--- a/code/html/_search.html
+++ b/code/html/_search.html
@@ -9,7 +9,8 @@
     data-target="application.search"
   />
   <div
-    class="hidden absolute top-0 left-0 right-0 bg-white z-20 p-4 mt-12 rounded border border-red-200 overflow-x-auto"
+    class="hidden absolute top-0 left-0 right-0 bg-white z-20 p-4 mt-12 rounded border border-red-200 overflow-x-auto overflow-y-auto"
     data-target="search.results"
+    style="max-height: 75vh;"
   ></div>
 </form>

--- a/code/javascripts/controllers/search_controller.js
+++ b/code/javascripts/controllers/search_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
     this.client = algoliasearch(process.env.ALGOLIA_APP_ID, process.env.ALGOLIA_SEARCH_KEY)
     this.index = this.client.initIndex(process.env.ALGOLIA_INDEX_NAME)
     this.searchOptions = {
-      hitsPerPage: 3,
+      hitsPerPage: 50,
       attributesToRetrieve: '*',
       attributesToSnippet: 'text:20,section:20',
       attributesToHighlight: null,

--- a/code/javascripts/controllers/search_controller.js
+++ b/code/javascripts/controllers/search_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
     this.client = algoliasearch(process.env.ALGOLIA_APP_ID, process.env.ALGOLIA_SEARCH_KEY)
     this.index = this.client.initIndex(process.env.ALGOLIA_INDEX_NAME)
     this.searchOptions = {
-      hitsPerPage: 50,
+      hitsPerPage: 10,
       attributesToRetrieve: '*',
       attributesToSnippet: 'text:20,section:20',
       attributesToHighlight: null,


### PR DESCRIPTION
Right now, for any given search, we only provides 3 results:

![image](https://user-images.githubusercontent.com/32992335/111248306-dea05380-85c6-11eb-998f-0b185a02b2ab.png)

While it's better than nothing, it just isn't enough. The first few results should always be the most relevant, but we should provide a lot more. This PR changes the `hitsPerPage` from `3` to `50`. The new number, `50`, is arbitrary. Open to suggestions on exactly how many more a lot more is.

To accommodate this change, the dialog's height is capped and y-overflow is set to scroll: https://s.tape.sh/DF7FXh2b.

This isn't a replacement for actually having good search--tending to the index, etc. But, it's a fix we can make right now for the immediate better.
