### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,7 +33,7 @@ Take a visit to the [CLI Doc](https://redwoodjs.com/docs/cli-commands.html) to s
 
 Redwood generators make monotonous developer tasks a breeze. Creating all the boilerplate code required for CRUD operations on a model can be accomplished with a few commands. Three to be exact. 
 
-Every new Redwood project comes with a default Model called UserExample in `api/db/schema.prisma` (ignore the rest of the file for now, it's for more advanced configuration data)
+Every new Redwood project comes with a default Model called UserExample in `api/db/schema.prisma` (ignore the rest of the file for now, it's for more advanced configuration data).
 
 ```
 model UserExample {

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,7 +33,7 @@ Take a visit to the [CLI Doc](https://redwoodjs.com/docs/cli-commands.html) to s
 
 Redwood generators make monotonous developer tasks a breeze. Creating all the boilerplate code required for CRUD operations on a model can be accomplished with a few commands. Three to be exact. 
 
-Every new Redwood project comes with a default Model called UserExample in `api/db/schema.prisma`. 
+Every new Redwood project comes with a default Model called UserExample in `api/db/schema.prisma` (ignore the rest of the file for now, it's for more advanced configuration data)
 
 ```
 model UserExample {


### PR DESCRIPTION
Following @cannikin's preference to address the issue I originally reported as "This visual suggests that the UserExample model is the only content in the file `api/db/schema.prisma` 

