### PR TITLE
Wraps the version number in a link to the github releases page

### DIFF
--- a/code/html/layouts/application.html
+++ b/code/html/layouts/application.html
@@ -41,7 +41,9 @@
             </div>
             <div class="flex items-center">
               <div class="text-red-700 font-mono font-semibold mr-8">
-                @@version
+                <a class="hover:underline" href="https://github.com/redwoodjs/redwood/releases" title="Go to Redwood's Releases">
+                  @@version
+                </a>
               </div>
               <div class="ml-8 lg:hidden w-10 p-2" data-action="click->application#toggleNav">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current text-gray-700">


### PR DESCRIPTION
Redwood moves quickly, however I can never remember where to find the releases to see what's new & exciting. 

My proposed solution to this is to link the version number in the nav to the `releases` in github so people can easily find out what has been changed recently in the project.

![image](https://user-images.githubusercontent.com/13946/113778173-b4d3db80-96f1-11eb-9332-6504cc68a163.png)
