### PR TITLE
[v0.31] Creating Render Deploy Commands and Instructions

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -407,6 +407,8 @@ For hosting providers that auto deploy from Git, the deploy command runs the set
 **AWS**  
 This command runs the steps to both build your project _and_ deploy it to AWS.
 
+<br />
+
 ```
 yarn redwood deploy <target>
 ```

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -105,6 +105,7 @@ web/src/Routes.js:17:19: error (INVALID_ROUTE_PATH_SYNTAX): Error: Route path co
 ## console (alias c)
 
 Launch an interactive Redwood shell (experimental):
+
 - This has not yet been tested on Windows.
 - The Prisma Client must be generated _prior_ to running this command, e.g. `yarn redwood prisma generate`. This is a known issue.
 
@@ -136,7 +137,7 @@ yarn redwood dataMigrate <command>
 | Command   | Description                                                                                 |
 | :-------- | :------------------------------------------------------------------------------------------ |
 | `install` | Appends `DataMigration` model to `schema.prisma`, creates `api/db/dataMigrations` directory |
-| `up`      | Executes outstanding data migrations                                                         |
+| `up`      | Executes outstanding data migrations                                                        |
 
 ### install
 
@@ -166,7 +167,6 @@ Database tools.
 >
 > As of `v0.25`, `yarn redwood db <command>` has been deprecated in favor of `yarn redwood prisma <command>`. Click [here](#prisma) to skip to the prisma section below.
 
-
 ```
 yarn redwood db <command>
 ```
@@ -174,6 +174,7 @@ yarn redwood db <command>
 <br/>
 
 <!-- new command? link? deprecated b4... -->
+
 | Command            | Description                                                                                           |
 | :----------------- | :---------------------------------------------------------------------------------------------------- |
 | `down [decrement]` | Migrate your database down                                                                            |
@@ -237,7 +238,7 @@ This means that `yarn redwood db generate` needs to be run after every change to
 
 ### introspect
 
-Introspect your database and generate models in `./api/db/schema.prisma`, overedwoodriting existing models.
+Introspect your database and generate models in `./api/db/schema.prisma`, overwriting existing models.
 
 > **WARNING**
 >
@@ -294,10 +295,10 @@ Seed your database with test data.
 > As of `v0.25`, `yarn redwood db <command>` has been deprecated in favor of `yarn redwood prisma <command>`. Click [here](#prisma) to skip to the prisma section below.
 
 ```terminal
-yarn redwood db seed
+yarn redwood prisma db seed
 ```
 
-Runs `seed.js` in `./api/db`. `seed.js` instantiates the Prisma client and provides an async main function where you can put any seed data&mdash;data that needs to exist for your app to run. See the [example blog's seed.js file](https://github.com/redwoodjs/example-blog/blob/master/api/db/seeds.js).
+Runs `seed.js` in `./api/db`. `seed.js` instantiates the Prisma client and provides an async main function where you can put any seed data&mdash;data that needs to exist for your app to run. See the [example blog's seed.js file](https://github.com/redwoodjs/example-blog/blob/master/api/db/seed.js).
 
 ### studio
 
@@ -360,9 +361,9 @@ yarn redwood dev [side..]
 
 `yarn redwood dev api` starts the Redwood dev server and `yarn redwood dev web` starts the Webpack dev server with Redwood's config.
 
-| Argument           | Description                                                                                                                          |
-| :----------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| `side`             | Which dev server(s) to start. Choices are `api` and `web`. Defaults to `api` and `web`                                               |
+| Argument           | Description                                                                                                                                                                                                         |
+| :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `side`             | Which dev server(s) to start. Choices are `api` and `web`. Defaults to `api` and `web`                                                                                                                              |
 | `--forward, --fwd` | String of one or more Webpack Dev Server config options. See example usage below. See the [Redwood Webpack Doc](https://redwoodjs.com/docs/webpack-configuration#webpack-dev-server) for more details and examples. |
 
 **Usage**
@@ -389,6 +390,7 @@ Using `--forward` (alias `--fwd`), you can pass one or more Webpack Dev Server [
 ```
 
 You may need to access your dev application from a different host, like your mobile device. To resolve the “Invalid Host Header” message, run the following:
+
 ```bash
 ~/redwood-app$ yarn redwood dev --fwd="--disable-host-check"
 ```
@@ -397,13 +399,13 @@ For the full list of Webpack Dev Server settings, see [this documentation](https
 
 ## deploy
 
-Deploy your redwood project to a hosting provider target. 
+Deploy your redwood project to a hosting provider target.
 
-For Jamstack hosting providers like Netlify and Vercel, the deploy command runs the set of steps to build, apply production DB changes, and apply data migrations. In this context, it is often referred to as a Build Command. 
+**Netlify, Vercel, and Render**  
+For hosting providers that auto deploy from Git, the deploy command runs the set of steps to build, apply production DB changes, and apply data migrations. In this context, it is often referred to as a Build Command. _Note: for Render, which uses traditional infrastructure, the command also starts Redwood's api server._
 
-For Render, this command takes an additional argument to select if to build the api or web side.
-
-For hosting providers like AWS, this command runs the steps to both build your project _and_ deploy it to AWS. 
+**AWS**  
+This command runs the steps to both build your project _and_ deploy it to AWS.
 
 ```
 yarn redwood deploy <target>
@@ -411,12 +413,12 @@ yarn redwood deploy <target>
 
 <br/>
 
-| Commands          | Description                                                            |
-| :--------------- | :--------------------------------------------------------------------- |
-| `aws <provider>` | Deploy to AWS using the selected provider [choices: "serverless"] |
-| `netlify [...commands]` | Build command for Netlify deploy |
-| `vercel [...commands]` | Build command for Vercel deploy |
-| `render <side> [...commands]` | Build command for Render deploy
+| Commands                | Description                                                       |
+| :---------------------- | :---------------------------------------------------------------- |
+| `aws <provider>`        | Deploy to AWS using the selected provider [choices: "serverless"] |
+| `netlify [...commands]` | Build command for Netlify deploy                                  |
+| `render <side> [...commands]`  | Build command for Render deploy                                   |
+| `vercel [...commands]`  | Build command for Vercel deploy                                   |
 
 ### aws
 
@@ -428,10 +430,10 @@ yarn redwood deploy aws [provider]
 
 <br/>
 
-| Options & Arguments  | Description                              |
-| :------------------- | :--------------------------------------- |
-| `provider`           | AWS Deploy provider to configure [choices: "serverless"] [default: "serverless"] |
-| `--side     `        | which Side(s)to deploy [choices: "api"] [default: "api"]  |
+| Options & Arguments | Description                                                                      |
+| :------------------ | :------------------------------------------------------------------------------- |
+| `provider`          | AWS Deploy provider to configure [choices: "serverless"] [default: "serverless"] |
+| `--side`            | which Side(s)to deploy [choices: "api"] [default: "api"]                         |
 
 ### netlify
 
@@ -443,36 +445,45 @@ yarn redwood deploy netlify
 
 <br/>
 
-| Options  | Description                              |
-| :------------------- | :--------------------------------------- |
-| `--build`           | Build for production [default: "true"] |
-| `--prisma`        | Apply database migrations [default: "true"]  |
-| `--data-migrate, --dm` | Migrate the data in your database [default: "true"]  |
+| Options                | Description                                          |
+| :--------------------- | :--------------------------------------------------- |
+| `--build`              | Build for production [default: "true"]               |
+| `--prisma`             | Apply database migrations [default: "true"]          |
+| `--data-migrate, --dm` | Migrate the data in your database [default: "true"] |
 
 **Example**
 The following command will build, apply Prisma DB migrations, and skip data migrations.
+
 ```
 yarn redwood deploy netlify --no-data-migrate
 ```
 
 ### render
 
-Build command for Render deploy
+Build (web) and Start (api) command for Render deploy. (For usage instructions, see the Render [Deploy Redwood](https://render.com/docs/deploy-redwood) doc.)
 
 ```
-yarn redwood deploy render [side]
+yarn redwood deploy render <side>
 ```
 
 <br/>
 
-| Options & Arguments  | Description                              |
-| :------------------- | :--------------------------------------- |
-| `side`               | Select side to build [choices: "api", "web"] |
-| `--build`           | Build for production [default: "true"] |
-| `--prisma`        | Apply database migrations [default: "true"]  |
-| `--data-migrate, --dm` | Migrate the data in your database [default: "true"]  |
+| Options & Arguments    | Description                                          |
+| :--------------------- | :--------------------------------------------------- |
+| `side`                 | select side to build [choices: "api", "web"]         |
+| `--prisma`             | Apply database migrations [default: "true"]          |
+| `--data-migrate, --dm` | Migrate the data in your database [default: "true"] |
+| `--serve`              | Run server for api in production [default: "true"]   |
 
-**Example** The following command will build the api
+**Example**
+The following command will build the Web side for static-site CDN deployment.
+
+```
+yarn redwood deploy render web
+```
+
+The following command will apply Prisma DB migrations, run data migrations, and start the api server.
+
 ```
 yarn redwood deploy render api
 ```
@@ -487,14 +498,15 @@ yarn redwood deploy vercel
 
 <br/>
 
-| Options  | Description                              |
-| :------------------- | :--------------------------------------- |
-| `--build`           | Build for production [default: "true"] |
-| `--prisma`        | Apply database migrations [default: "true"]  |
-| `--data-migrate, --dm` | Migrate the data in your database [default: "true"]  |
+| Options                | Description                                          |
+| :--------------------- | :--------------------------------------------------- |
+| `--build`              | Build for production [default: "true"]               |
+| `--prisma`             | Apply database migrations [default: "true"]          |
+| `--data-migrate, --dm` | Migrate the data in your database [default: "true"] |
 
 **Example**
 The following command will build, apply Prisma DB migrations, and skip data migrations.
+
 ```
 yarn redwood deploy vercel --no-data-migrate
 ```
@@ -964,12 +976,12 @@ A scaffold quickly creates a CRUD for a model by generating the following files 
 
 The content of the generated components is different from what you'd get by running them individually.
 
-| Arguments & Options  | Description                                                                                                                                                    |
-| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Arguments & Options  | Description                                                                                                                                                         |
+| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `model`              | Model to scaffold. You can also use `<path/model>` to nest files by type at the given path directory (or directories). For example, `redwood g scaffold admin/post` |
-| `--force, -f`        | Overwrite existing files                                                                                                                                       |
-| `--javascript, --js` | Generate JavaScript files                                                                                                                                      |
-| `--typescript, --ts` | Generate TypeScript files                                                                                                                                      |
+| `--force, -f`        | Overwrite existing files                                                                                                                                            |
+| `--javascript, --js` | Generate JavaScript files                                                                                                                                           |
+| `--typescript, --ts` | Generate TypeScript files                                                                                                                                           |
 
 **Usage**
 
@@ -1284,7 +1296,7 @@ Redwood's `prisma` command is a lightweight wrapper around the Prisma CLI. It's 
 > **What do you mean it's a lightweight wrapper?**
 >
 > By lightweight wrapper, we mean that we're handling some flags under the hood for you.
-> You can use the Prisma CLI directly (`yarn prisma`), but letting Redwood act as a proxy (`yarn redwood prisma`) saves you a lot of keystrokes. 
+> You can use the Prisma CLI directly (`yarn prisma`), but letting Redwood act as a proxy (`yarn redwood prisma`) saves you a lot of keystrokes.
 > For example, Redwood adds the `--preview-feature` and `--schema=api/db/schema.prisma` flags automatically.
 >
 > If you want to know exactly what `yarn redwood prisma <command>` runs, which flags it's passing, etc., it's right at the top:
@@ -1300,7 +1312,7 @@ Redwood's `prisma` command is a lightweight wrapper around the Prisma CLI. It's 
 
 Since `yarn redwood prisma` is just an entry point into all the database commands that the Prisma CLI has to offer, we won't try to provide an exhaustive reference of everything you can do with it here. Instead what we'll do is focus on some of the most common commands; those that you'll be running on a regular basis, and how they fit into Redwood's workflows.
 
-For the complete list of commands, see the [Prisma CLI Reference](https://www.prisma.io/docs/reference/api-reference/command-reference). It's the authority. 
+For the complete list of commands, see the [Prisma CLI Reference](https://www.prisma.io/docs/reference/api-reference/command-reference). It's the authority.
 
 Along with the CLI reference, bookmark Prisma's [Migration Flows](https://www.prisma.io/docs/concepts/components/prisma-migrate/prisma-migrate-flows) doc&mdash;it'll prove to be an invaluable resource for understanding `yarn redwood prisma migrate`.
 
@@ -1327,7 +1339,7 @@ Pull the schema from an existing database, updating the Prisma schema.
 > 👉 Quick link to the [Prisma CLI Reference](https://www.prisma.io/docs/reference/api-reference/command-reference#db-pull).
 
 ```
-yarn redwood prisma db pull 
+yarn redwood prisma db pull
 ```
 
 This command, formerly `introspect`, connects to your database and adds Prisma models to your Prisma schema that reflect the current database schema.
@@ -1341,12 +1353,12 @@ Push the state from your Prisma schema to your database.
 > 👉 Quick link to the [Prisma CLI Reference](https://www.prisma.io/docs/reference/api-reference/command-reference#db-push).
 
 ```
-yarn redwood prisma db push 
+yarn redwood prisma db push
 ```
 
 This is your go-to command for prototyping changes to your Prisma schema (`schema.prisma`).
 Prior to to `yarn redwood prisma db push`, there wasn't a great way to try out changes to your Prisma schema without creating a migration.
-This command fills the void by "pushing" your `schema.prisma` file to your database without creating a migration. You don't even have to run `yarn redwood prisma generate` afteredwoodard&mdash;it's all taken care of for you, making it ideal for iterative development.
+This command fills the void by "pushing" your `schema.prisma` file to your database without creating a migration. You don't even have to run `yarn redwood prisma generate` afterward&mdash;it's all taken care of for you, making it ideal for iterative development.
 
 #### seed
 
@@ -1382,7 +1394,7 @@ Update the database schema with migrations.
 yarn redwood prisma migrate <command>
 ```
 
-As a database toolkit, Prisma strives to be as holistic as possible. Prisma Migrate lets you use Prisma schema to make changes to your database declaratively, all while keeping things deterministic and fully customizable by generating the migration steps in a simple, familiar format: SQL. 
+As a database toolkit, Prisma strives to be as holistic as possible. Prisma Migrate lets you use Prisma schema to make changes to your database declaratively, all while keeping things deterministic and fully customizable by generating the migration steps in a simple, familiar format: SQL.
 
 Since migrate generates plain SQL files, you can edit those SQL files before applying the migration using `yarn redwood prisma migrate --create-only`. This creates the migration based on the changes in the Prisma schema, but doesn't apply it, giving you the chance to go in and make any modifications you want. [Daniel Norman's tour of Prisma Migrate](https://www.youtube.com/watch?v=0LKhksstrfg) demonstrates this and more to great effect.
 
@@ -1432,14 +1444,14 @@ yarn redwood setup <command>
 
 <br/>
 
-| Commands   | Description                                                            |
-| :--------- | :--------------------------------------------------------------------- |
-| `auth`     | Setup auth configuration for a provider                               |
-| `custom-web-index`     | Setup an `index.js` file, so you can customize how Redwood web is mounted in your browser |
-| `deploy`   | Setup a deployment configuration for  a provider                       |
-| `i18n`     | Setup i18n                                                             |
-| `tailwind` | Setup tailwindcss and PostCSS                                          |
-| `webpack`  | Setup webpack config file in your project so you can add custom config |
+| Commands           | Description                                                                               |
+| :----------------- | :---------------------------------------------------------------------------------------- |
+| `auth`             | Setup auth configuration for a provider                                                   |
+| `custom-web-index` | Setup an `index.js` file, so you can customize how Redwood web is mounted in your browser |
+| `deploy`           | Setup a deployment configuration for a provider                                           |
+| `i18n`             | Setup i18n                                                                                |
+| `tailwind`         | Setup tailwindcss and PostCSS                                                             |
+| `webpack`          | Setup webpack config file in your project so you can add custom config                    |
 
 ### setup auth
 
@@ -1470,9 +1482,9 @@ yarn redwood setup custom-web-index
 
 Redwood automatically mounts your `<App />` to the DOM, but if you want to customize how that happens, you can use this setup command to generate a file where you can do that in.
 
-| Arguments & Options | Description                                                                                      |
-| :------------------ | :----------------------------------------------------------------------------------------------- |
-| `--force, -f`       | Overwrite existing files                                                                         |
+| Arguments & Options | Description              |
+| :------------------ | :----------------------- |
+| `--force, -f`       | Overwrite existing files |
 
 **Usage**
 
@@ -1490,9 +1502,9 @@ Creates provider-specific code and configuration for deployment.
 
 | Arguments & Options | Description                                                                        |
 | :------------------ | :--------------------------------------------------------------------------------- |
-| `provider`          | Deploy provider to configure. Choices are `netlify`, `render`, `vercel`, or `aws-serverless` |
-| `--database, -d`    | Database deployment for Render only. Choices are `postgres`, `sqlite` or `none`. [default: postgres]| 
-| `--force, -f`       | Overwrite existing configuration [default: false]         
+| `provider`          | Deploy provider to configure. Choices are `aws-serverless`, `netlify`, `render`, or `vercel` |
+| `--database, -d`    | Database deployment for Render only [choices: "none", "postgresql", "sqlite"] [default: "postgresql"]     |
+| `--force, -f`       | Overwrite existing configuration [default: false]                                  |
 
 ## storybook
 
@@ -1535,6 +1547,26 @@ yarn redwood test [side..]
 | `--watchAll`        | Run all tests                                                                                                                                                  |
 | `--collectCoverage` | Show test coverage summary and output info to `coverage` directory in project root. See this directory for an .html coverage report                            |
 | `--clearCache`      | Delete the Jest cache directory and exit without running tests                                                                                                 |
+
+## serve
+Run server for api in production, if you are self-hosting, or deploying into a serverfull environment.
+
+```terminal
+yarn redwood serve [side]
+```
+
+<br>
+
+| Arguments & Options | Description                                                                                                           |
+| :------------------ | :-------------------------------------------------------------------------------------------------------------------- |
+| `side`              | Which side(s) to run. Currently only supports `api`. Defaults to "api"                                                |
+| `--port`            | What port should the server run on [default: 8911]                                                                    |
+| `--socket`          | The socket the server should run. This takes precedence over port                                                     |
+| `--rootPath`        | The root path your api functions are served from i.e. localhost:`{port}`/`{rootPath}`/`{functionName}` [default: "/"] |
+
+
+
+<br>
 
 ## upgrade
 

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1465,8 +1465,9 @@ Creates provider-specific code and configuration for deployment.
 
 | Arguments & Options | Description                                                                        |
 | :------------------ | :--------------------------------------------------------------------------------- |
-| `provider`          | Deploy provider to configure. Choices are `netlify`, `vercel`, or `aws-serverless` |
-| `--force, -f`       | Overwrite existing configuration [default: false]         |
+| `provider`          | Deploy provider to configure. Choices are `netlify`, `render`, `vercel`, or `aws-serverless` |
+| `--database, -d`    | Database deployment for Render only. Choices are `postgres`, `sqlite` or `none`. [default: postgres]| 
+| `--force, -f`       | Overwrite existing configuration [default: false]         
 
 ## storybook
 

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -399,9 +399,11 @@ For the full list of Webpack Dev Server settings, see [this documentation](https
 
 Deploy your redwood project to a hosting provider target. 
 
-For Jamstack hosting providers like Netlify and Vercel, the deploy command runs the set of steps to build, apply production DB changes, and apply data migrations. In this context, it is often referred to as a Build Command.
+For Jamstack hosting providers like Netlify and Vercel, the deploy command runs the set of steps to build, apply production DB changes, and apply data migrations. In this context, it is often referred to as a Build Command. 
 
-For hosting providers like AWS, this command runs the steps to both build your project _and_ deploy it to AWS.
+For Render, this command takes an additional argument to select if to build the api or web side.
+
+For hosting providers like AWS, this command runs the steps to both build your project _and_ deploy it to AWS. 
 
 ```
 yarn redwood deploy <target>
@@ -414,6 +416,7 @@ yarn redwood deploy <target>
 | `aws <provider>` | Deploy to AWS using the selected provider [choices: "serverless"] |
 | `netlify [...commands]` | Build command for Netlify deploy |
 | `vercel [...commands]` | Build command for Vercel deploy |
+| `render <side> [...commands]` | Build command for Render deploy
 
 ### aws
 
@@ -435,7 +438,7 @@ yarn redwood deploy aws [provider]
 Build command for Netlify deploy
 
 ```
-yarn redwood deploy netlify [provider]
+yarn redwood deploy netlify
 ```
 
 <br/>
@@ -444,7 +447,7 @@ yarn redwood deploy netlify [provider]
 | :------------------- | :--------------------------------------- |
 | `--build`           | Build for production [default: "true"] |
 | `--prisma`        | Apply database migrations [default: "true"]  |
-| `--data-migrate, --dm` | wMigrate the data in your database [default: "true"]  |
+| `--data-migrate, --dm` | Migrate the data in your database [default: "true"]  |
 
 **Example**
 The following command will build, apply Prisma DB migrations, and skip data migrations.
@@ -452,12 +455,34 @@ The following command will build, apply Prisma DB migrations, and skip data migr
 yarn redwood deploy netlify --no-data-migrate
 ```
 
+### render
+
+Build command for Render deploy
+
+```
+yarn redwood deploy render [side]
+```
+
+<br/>
+
+| Options & Arguments  | Description                              |
+| :------------------- | :--------------------------------------- |
+| `side`               | Select side to build [choices: "api", "web"] |
+| `--build`           | Build for production [default: "true"] |
+| `--prisma`        | Apply database migrations [default: "true"]  |
+| `--data-migrate, --dm` | Migrate the data in your database [default: "true"]  |
+
+**Example** The following command will build the api
+```
+yarn redwood deploy render api
+```
+
 ### vercel
 
 Build command for Vercel deploy
 
 ```
-yarn redwood deploy vercel [provider]
+yarn redwood deploy vercel
 ```
 
 <br/>
@@ -466,7 +491,7 @@ yarn redwood deploy vercel [provider]
 | :------------------- | :--------------------------------------- |
 | `--build`           | Build for production [default: "true"] |
 | `--prisma`        | Apply database migrations [default: "true"]  |
-| `--data-migrate, --dm` | wMigrate the data in your database [default: "true"]  |
+| `--data-migrate, --dm` | Migrate the data in your database [default: "true"]  |
 
 **Example**
 The following command will build, apply Prisma DB migrations, and skip data migrations.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -94,7 +94,7 @@ For the complete deployment process on Netlify, see the [Tutorial Deployment sec
 ### Render tl;dr Deploy
 If you simply want to experience the Render deployment process with the Prisma database of your choice, you can do the following:
 1. create a new redwood project: `yarn create redwood-app ./render-deploy`
-2. after your "render-deploy" project installation is complete, init git, commit, and add it as a new repo to GitHub 
+2. after your "render-deploy" project installation is complete, init git, commit, and add it as a new repo to GitHub or GitLab 
 3. run the command `yarn rw setup deploy render`, use the flag `-database` to select from `postgres`, `sqlite` or `none` to proceed without a database
 4. follow the [Render Redwood Deploy Docs](https://render.com/docs/deploy-redwood) for detailed instructions
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,6 +1,6 @@
 # Deploy
 
-Redwood is designed for serverless architecture deployment, offering a unique continuous deployment process:
+Redwood is designed for both serverless and traditional infrastructure deployments, offering a unique continuous deployment process:
 
 1. code is committed to a repository on GitHub, GitLab, or Bitbucket, which triggers the deployment
 2. the Redwood API Side and Web Side are individually prepared via a build process
@@ -11,6 +11,7 @@ Currently, these are the officially supported deploy targets:
 - [Netlify](https://www.netlify.com/)
 - [Vercel](https://vercel.com)
 - [AWS-Serverless](https://serverless.com)
+- [Render](https://render.com)
 
 Redwood has a CLI generator that adds the code and configuration required by the specified provider (see the [CLI Doc](https://redwoodjs.com/docs/cli-commands#deploy-config) for more information):
 ```shell
@@ -91,6 +92,7 @@ If you simply want to experience the Netlify deployment process without a databa
 For the complete deployment process on Netlify, see the [Tutorial Deployment section](https://redwoodjs.com/tutorial/deployment).
 
 ## Render Deploy
+Render is a unified cloud to build and run all your apps and websites with free SSL, a global CDN, private networks and auto deploys from Git — **database included**!
 ### Render tl;dr Deploy
 If you simply want to experience the Render deployment process with the Prisma database of your choice, you can do the following:
 1. create a new redwood project: `yarn create redwood-app ./render-deploy`

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,6 +1,6 @@
 # Deploy
 
-Redwood is designed for both serverless and traditional infrastructure deployments, offering a unique continuous deployment process:
+Redwood is designed for both serverless and traditional infrastructure deployments, offering a unique continuous deployment process in both cases:
 
 1. code is committed to a repository on GitHub, GitLab, or Bitbucket, which triggers the deployment
 2. the Redwood API Side and Web Side are individually prepared via a build process

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -90,6 +90,13 @@ If you simply want to experience the Netlify deployment process without a databa
 ### Netlify Complete Deploy Walkthrough
 For the complete deployment process on Netlify, see the [Tutorial Deployment section](https://redwoodjs.com/tutorial/deployment).
 
+## Render Deploy
+### Render tl;dr Deploy
+If you simply want to experience the Render deployment process with the Prisma database of your choice, you can do the following:
+1. create a new redwood project: `yarn create redwood-app ./render-deploy`
+2. after your "render-deploy" project installation is complete, init git, commit, and add it as a new repo to GitHub 
+3. run the command `yarn rw setup deploy render`, use the flag `-database` to select from `postgres`, `sqlite` or `none` to proceed without a database
+4. follow the [Render Redwood Deploy Docs](https://render.com/docs/deploy-redwood) for detailed instructions
 
 ## Vercel Deploy
 >The following instructions assume you have read the [General Deployment Setup](#general-deployment-setup) section above.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -94,7 +94,7 @@ For the complete deployment process on Netlify, see the [Tutorial Deployment sec
 ## Render Deploy
 Render is a unified cloud to build and run all your apps and websites with free SSL, a global CDN, private networks and auto deploys from Git — **database included**!
 ### Render tl;dr Deploy
-If you simply want to experience the Render deployment process with the Prisma database of your choice, you can do the following:
+If you simply want to experience the Render deployment process, including a Postgres or SQLite database, you can do the following:
 1. create a new redwood project: `yarn create redwood-app ./render-deploy`
 2. after your "render-deploy" project installation is complete, init git, commit, and add it as a new repo to GitHub or GitLab 
 3. run the command `yarn rw setup deploy render`, use the flag `-database` to select from `postgres`, `sqlite` or `none` to proceed without a database


### PR DESCRIPTION
This change adds the documentation to deploy Redwood to Render.
- https://redwoodjs.com/docs/deploy#render
- https://redwoodjs.com/docs/cli-commands#deploy
- https://redwoodjs.com/docs/cli-commands#setup

This PR should not be merged until [https://github.com/redwoodjs/redwood/pull/2099]() is complete