### PR TITLE
Fix typo and format tables

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -430,7 +430,7 @@ yarn redwood deploy aws [provider]
 | Options & Arguments | Description                                                                      |
 | :------------------ | :------------------------------------------------------------------------------- |
 | `provider`          | AWS Deploy provider to configure [choices: "serverless"] [default: "serverless"] |
-| `--side     `       | which Side(s)to deploy [choices: "api"] [default: "api"]                         |
+| `--side`            | which Side(s)to deploy [choices: "api"] [default: "api"]                         |
 
 ### netlify
 
@@ -1415,7 +1415,7 @@ yarn redwood setup <command>
 | :----------------- | :---------------------------------------------------------------------------------------- |
 | `auth`             | Setup auth configuration for a provider                                                   |
 | `custom-web-index` | Setup an `index.js` file, so you can customize how Redwood web is mounted in your browser |
-| `deploy`           | Setup a deployment configuration for  a provider                                          |
+| `deploy`           | Setup a deployment configuration for a provider                                           |
 | `i18n`             | Setup i18n                                                                                |
 | `tailwind`         | Setup tailwindcss and PostCSS                                                             |
 | `webpack`          | Setup webpack config file in your project so you can add custom config                    |

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -46,7 +46,7 @@ yarn redwood build [side..]
 We use Babel to transpile the api side into `./api/dist` and Webpack to package the web side into `./web/dist`.
 
 | Arguments & Options | Description                                                                                                                                                                 |
-|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `side`              | Which side(s) to build. Choices are `api` and `web`. Defaults to `api` and `web`                                                                                            |
 | `--stats`           | Use [Webpack Bundle Analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) to visualize the size of Webpack output files via an interactive zoomable treemap |
 | `--verbose, -v`     | Print more information while building                                                                                                                                       |
@@ -135,7 +135,7 @@ yarn redwood dataMigrate <command>
 <br/>
 
 | Command   | Description                                                                                 |
-|:----------|:--------------------------------------------------------------------------------------------|
+| :-------- | :------------------------------------------------------------------------------------------ |
 | `install` | Appends `DataMigration` model to `schema.prisma`, creates `api/db/dataMigrations` directory |
 | `up`      | Executes outstanding data migrations                                                        |
 
@@ -176,7 +176,7 @@ yarn redwood db <command>
 <!-- new command? link? deprecated b4... -->
 
 | Command            | Description                                                                                           |
-|:-------------------|:------------------------------------------------------------------------------------------------------|
+| :----------------- | :---------------------------------------------------------------------------------------------------- |
 | `down [decrement]` | Migrate your database down                                                                            |
 | `generate`         | Generate the Prisma client                                                                            |
 | `introspect`       | Introspect your database and generate models in `./api/db/schema.prisma`, overwriting existing models |
@@ -200,7 +200,7 @@ yarn redwood db down [decrement]
 <br/>
 
 | Argument    | Description                                              |
-|:------------|:---------------------------------------------------------|
+| :---------- | :------------------------------------------------------- |
 | `decrement` | Number of backwards migrations to apply. Defaults to `1` |
 
 **Example**
@@ -263,7 +263,7 @@ yarn redwood db save [name..]
 A migration defines the steps necessary to update your current schema.
 
 | Argument | Description           |
-|:---------|:----------------------|
+| :------- | :-------------------- |
 | `name`   | Name of the migration |
 
 Running `yarn redwood db save` generates the following directories and files as necessary:
@@ -327,7 +327,7 @@ yarn redwood db up [increment]
 <br/>
 
 | Arguments & Options | Description                                                   |
-|:--------------------|:--------------------------------------------------------------|
+| :------------------ | :------------------------------------------------------------ |
 | `increment`         | Number of forward migrations to apply. Defaults to the latest |
 | `--autoApprove`     | Skip interactive approval before migrating                    |
 | `--dbClient`        | Generate the Prisma client                                    |
@@ -362,7 +362,7 @@ yarn redwood dev [side..]
 `yarn redwood dev api` starts the Redwood dev server and `yarn redwood dev web` starts the Webpack dev server with Redwood's config.
 
 | Argument           | Description                                                                                                                                                                                                         |
-|:-------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `side`             | Which dev server(s) to start. Choices are `api` and `web`. Defaults to `api` and `web`                                                                                                                              |
 | `--forward, --fwd` | String of one or more Webpack Dev Server config options. See example usage below. See the [Redwood Webpack Doc](https://redwoodjs.com/docs/webpack-configuration#webpack-dev-server) for more details and examples. |
 
@@ -412,7 +412,7 @@ yarn redwood deploy <target>
 <br/>
 
 | Commands                | Description                                                       |
-|:------------------------|:------------------------------------------------------------------|
+| :---------------------- | :---------------------------------------------------------------- |
 | `aws <provider>`        | Deploy to AWS using the selected provider [choices: "serverless"] |
 | `netlify [...commands]` | Build command for Netlify deploy                                  |
 | `vercel [...commands]`  | Build command for Vercel deploy                                   |
@@ -428,9 +428,9 @@ yarn redwood deploy aws [provider]
 <br/>
 
 | Options & Arguments | Description                                                                      |
-|:--------------------|:---------------------------------------------------------------------------------|
+| :------------------ | :------------------------------------------------------------------------------- |
 | `provider`          | AWS Deploy provider to configure [choices: "serverless"] [default: "serverless"] |
-| `--side `           | which Side(s)to deploy [choices: "api"] [default: "api"]                         |
+| `--side     `       | which Side(s)to deploy [choices: "api"] [default: "api"]                         |
 
 ### netlify
 
@@ -443,7 +443,7 @@ yarn redwood deploy netlify [provider]
 <br/>
 
 | Options                | Description                                          |
-|:-----------------------|:-----------------------------------------------------|
+| :--------------------- | :--------------------------------------------------- |
 | `--build`              | Build for production [default: "true"]               |
 | `--prisma`             | Apply database migrations [default: "true"]          |
 | `--data-migrate, --dm` | wMigrate the data in your database [default: "true"] |
@@ -466,7 +466,7 @@ yarn redwood deploy vercel [provider]
 <br/>
 
 | Options                | Description                                          |
-|:-----------------------|:-----------------------------------------------------|
+| :--------------------- | :--------------------------------------------------- |
 | `--build`              | Build for production [default: "true"]               |
 | `--prisma`             | Apply database migrations [default: "true"]          |
 | `--data-migrate, --dm` | wMigrate the data in your database [default: "true"] |
@@ -489,7 +489,7 @@ yarn redwood d <type>
 <br/>
 
 | Command              | Description                                                                     |
-|:---------------------|:--------------------------------------------------------------------------------|
+| :------------------- | :------------------------------------------------------------------------------ |
 | `cell <name>`        | Destroy a cell component                                                        |
 | `component <name>`   | Destroy a component                                                             |
 | `function <name>`    | Destroy a Function                                                              |
@@ -510,7 +510,7 @@ yarn redwood generate <type>
 Some generators require that their argument be a model in your `schema.prisma`. When they do, their argument is named `<model>`.
 
 | Command                | Description                                                                                           |
-|:-----------------------|:------------------------------------------------------------------------------------------------------|
+| :--------------------- | :---------------------------------------------------------------------------------------------------- |
 | `cell <name>`          | Generate a cell component                                                                             |
 | `component <name>`     | Generate a component component                                                                        |
 | `dataMigration <name>` | Generate a data migration component                                                                   |
@@ -538,7 +538,7 @@ yarn redwood generate cell <name>
 Cells are signature to Redwood. We think they provide a simpler and more declarative approach to data fetching.
 
 | Arguments & Options  | Description                              |
-|:---------------------|:-----------------------------------------|
+| :------------------- | :--------------------------------------- |
 | `name`               | Name of the cell                         |
 | `--force, -f`        | Overwrite existing files                 |
 | `--javascript, --js` | Generate JavaScript files                |
@@ -605,7 +605,7 @@ yarn redwood generate component <name>
 Redwood loves function components and makes extensive use of React Hooks, which are only enabled in function components.
 
 | Arguments & Options  | Description                              |
-|:---------------------|:-----------------------------------------|
+| :------------------- | :--------------------------------------- |
 | `name`               | Name of the component                    |
 | `--force, -f`        | Overwrite existing files                 |
 | `--javascript, --js` | Generate JavaScript files                |
@@ -661,7 +661,7 @@ yarn redwood generate dataMigration <name>
 Creates a data migration script in `api/db/dataMigrations`.
 
 | Arguments & Options | Description                                                              |
-|:--------------------|:-------------------------------------------------------------------------|
+| :------------------ | :----------------------------------------------------------------------- |
 | `name`              | Name of the data migration, prefixed with a timestamp at generation time |
 
 **Usage**
@@ -683,7 +683,7 @@ yarn redwood generate function <name>
 Not to be confused with Javascript functions, Capital-F Functions are meant to be deployed to serverless endpoints like AWS Lambda.
 
 | Arguments & Options | Description              |
-|:--------------------|:-------------------------|
+| :------------------ | :----------------------- |
 | `name`              | Name of the function     |
 | `--force, -f`       | Overwrite existing files |
 
@@ -750,7 +750,7 @@ yarn redwood generate layout <name>
 Layouts wrap pages and help you stay DRY.
 
 | Arguments & Options  | Description                              |
-|:---------------------|:-----------------------------------------|
+| :------------------- | :--------------------------------------- |
 | `name`               | Name of the layout                       |
 | `--force, -f`        | Overwrite existing files                 |
 | `--javascript, --js` | Generate JavaScript files                |
@@ -811,7 +811,7 @@ from `name` and the route parameter, if specified, will be added to the end.
 This also updates `Routes.js` in `./web/src`.
 
 | Arguments & Options | Description                              |
-|:--------------------|:-----------------------------------------|
+| :------------------ | :--------------------------------------- |
 | `name`              | Name of the page                         |
 | `path`              | URL path to the page. Defaults to `name` |
 | `--force, -f`       | Overwrite existing files                 |
@@ -944,7 +944,7 @@ A scaffold quickly creates a CRUD for a model by generating the following files 
 The content of the generated components is different from what you'd get by running them individually.
 
 | Arguments & Options  | Description                                                                                                                                                         |
-|:---------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `model`              | Model to scaffold. You can also use `<path/model>` to nest files by type at the given path directory (or directories). For example, `redwood g scaffold admin/post` |
 | `--force, -f`        | Overwrite existing files                                                                                                                                            |
 | `--javascript, --js` | Generate JavaScript files                                                                                                                                           |
@@ -1020,7 +1020,7 @@ The sdl will inspect your `schema.prisma` and will do its best with relations. S
 https://community.redwoodjs.com/t/prisma-beta-2-and-redwoodjs-limited-generator-support-for-relations-with-workarounds/361 -->
 
 | Arguments & Options  | Description                   |
-|:---------------------|:------------------------------|
+| :------------------- | :---------------------------- |
 | `model`              | Model to generate the sdl for |
 | `--crud`             | Also generate mutations       |
 | `--force, -f`        | Overwrite existing files      |
@@ -1146,7 +1146,7 @@ yarn redwood generate service <name>
 Services are where Redwood puts its business logic. They can be used by your GraphQL API or any other place in your backend code. See [How Redwood Works with Data](https://redwoodjs.com/tutorial/side-quest-how-redwood-works-with-data).
 
 | Arguments & Options  | Description                              |
-|:---------------------|:-----------------------------------------|
+| :------------------- | :--------------------------------------- |
 | `name`               | Name of the service                      |
 | `--force, -f`        | Overwrite existing files                 |
 | `--javascript, --js` | Generate JavaScript files                |
@@ -1239,7 +1239,7 @@ yarn redwood lint
 <br/>
 
 | Option  | Description       |
-|:--------|:------------------|
+| :------ | :---------------- |
 | `--fix` | Try to fix errors |
 
 ## open
@@ -1284,7 +1284,7 @@ For the complete list of commands, see the [Prisma CLI Reference](https://www.pr
 Along with the CLI reference, bookmark Prisma's [Migration Flows](https://www.prisma.io/docs/concepts/components/prisma-migrate/prisma-migrate-flows) doc&mdash;it'll prove to be an invaluable resource for understanding `yarn redwood prisma migrate`.
 
 | Command             | Description                                                  |
-|:--------------------|:-------------------------------------------------------------|
+| :------------------ | :----------------------------------------------------------- |
 | `db <command>`      | Manage your database schema and lifecycle during development |
 | `generate`          | Generate artifacts (e.g. Prisma Client)                      |
 | `migrate <command>` | Update the database schema with migrations                   |
@@ -1325,7 +1325,7 @@ yarn redwood prisma db push
 
 This is your go-to command for prototyping changes to your Prisma schema (`schema.prisma`).
 Prior to to `yarn redwood prisma db push`, there wasn't a great way to try out changes to your Prisma schema without creating a migration.
-This command fills the void by "pushing" your `schema.prisma` file to your database without creating a migration. You don't even have to run `yarn redwood prisma generate` afteredwoodard&mdash;it's all taken care of for you, making it ideal for iterative development.
+This command fills the void by "pushing" your `schema.prisma` file to your database without creating a migration. You don't even have to run `yarn redwood prisma generate` afterward&mdash;it's all taken care of for you, making it ideal for iterative development.
 
 #### seed
 
@@ -1412,10 +1412,10 @@ yarn redwood setup <command>
 <br/>
 
 | Commands           | Description                                                                               |
-|:-------------------|:------------------------------------------------------------------------------------------|
+| :----------------- | :---------------------------------------------------------------------------------------- |
 | `auth`             | Setup auth configuration for a provider                                                   |
 | `custom-web-index` | Setup an `index.js` file, so you can customize how Redwood web is mounted in your browser |
-| `deploy`           | Setup a deployment configuration for a provider                                           |
+| `deploy`           | Setup a deployment configuration for  a provider                                          |
 | `i18n`             | Setup i18n                                                                                |
 | `tailwind`         | Setup tailwindcss and PostCSS                                                             |
 | `webpack`          | Setup webpack config file in your project so you can add custom config                    |
@@ -1431,7 +1431,7 @@ yarn redwood setup auth <provider>
 You can get authentication out-of-the-box with generators. Right now we support Auth0, Firebase, GoTrue, Magic, and Netlify.
 
 | Arguments & Options | Description                                                                                      |
-|:--------------------|:-------------------------------------------------------------------------------------------------|
+| :------------------ | :----------------------------------------------------------------------------------------------- |
 | `provider`          | Auth provider to configure. Choices are `auth0`, `firebase`, `goTrue`, `magicLink` and `netlify` |
 | `--force, -f`       | Overwrite existing files                                                                         |
 
@@ -1450,7 +1450,7 @@ yarn redwood setup custom-web-index
 Redwood automatically mounts your `<App />` to the DOM, but if you want to customize how that happens, you can use this setup command to generate a file where you can do that in.
 
 | Arguments & Options | Description              |
-|:--------------------|:-------------------------|
+| :------------------ | :----------------------- |
 | `--force, -f`       | Overwrite existing files |
 
 **Usage**
@@ -1468,7 +1468,7 @@ yarn redwood setup deploy <provider>
 Creates provider-specific code and configuration for deployment.
 
 | Arguments & Options | Description                                                                        |
-|:--------------------|:-----------------------------------------------------------------------------------|
+| :------------------ | :--------------------------------------------------------------------------------- |
 | `provider`          | Deploy provider to configure. Choices are `netlify`, `vercel`, or `aws-serverless` |
 | `--force, -f`       | Overwrite existing configuration [default: false]                                  |
 
@@ -1489,7 +1489,7 @@ yarn redwood storybook
 RedwoodJS supports Storybook by creating stories when generating cells, components, layouts and pages. You can then use these to describe how to render that UI component with representative data.
 
 | Arguments & Options | Description                                       |
-|:--------------------|:--------------------------------------------------|
+| :------------------ | :------------------------------------------------ |
 | `--open`            | Open Storybook in your browser on start           |
 | `--build`           | Build Storybook                                   |
 | `--port`            | Which port to run Storybook on (defaults to 7910) |
@@ -1505,7 +1505,7 @@ yarn redwood test [side..]
 <br/>
 
 | Arguments & Options | Description                                                                                                                                                    |
-|:--------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `side`              | Which side(s) to test. Choices are `api, web`. Defaults to "watch mode"                                                                                        |
 | `--help`            | Show help                                                                                                                                                      |
 | `--version`         | Show version number                                                                                                                                            |
@@ -1524,7 +1524,7 @@ yarn redwood serve [side]
 <br>
 
 | Arguments & Options | Description                                                                                                           |
-|:--------------------|:----------------------------------------------------------------------------------------------------------------------|
+| :------------------ | :-------------------------------------------------------------------------------------------------------------------- |
 | `side`              | Which side(s) to run. Currently only supports `api`. Defaults to "api"                                                |
 | `--port`            | What port should the server run on [default: 8911]                                                                    |
 | `--socket`          | The socket the server should run. This takes precedence over port                                                     |
@@ -1549,7 +1549,7 @@ Besides upgrading to a new stable release, you can use this command to upgrade t
 A canary release is published to npm every time a PR is merged to the `main` branch, and when we're getting close to a new release, we publish release candidates.
 
 | Option          | Description                                                                                                                                                                                                        |
-|:----------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--dry-run, -d` | Check for outdated packages without upgrading                                                                                                                                                                      |
 | `--tag, -t`     | Choices are "canary", "rc", or a specific version (e.g. "0.19.3"). WARNING: Unstable releases in the case of "canary" and "rc", which will force upgrade packages to the most recent release of the specified tag. |
 | `--pr`          | Installs packages for the given PR                                                                                                                                                                                 |


### PR DESCRIPTION
This PR:
- [x] Fixes a typo that was a possible find/replace victim (`afterward` --> `afteredwood`)
- [x] Formats markdown tables

The formatting was an auto-save from my VS Code. I'm happy to take that out if it's not appropriate. 