### PR TITLE
Document RouteFocus

### DIFF
--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -1,6 +1,6 @@
 # Accessibility (aka a11y)
 
-We built Redwood to make building websites more accessible (_we write all the config so you don't have to_), but Redwood's also built to help you make more accessible websites. Accessibility shouldn't be a nice-to-have. It should be a given from the start, a core feature that's built-in and well-supported.
+We built Redwood to make building websites more accessible (we write all the config so you don't have to), but Redwood's also built to help you make more accessible websites. Accessibility shouldn't be a nice-to-have. It should be a given from the start, a core feature that's built-in and well-supported.
 
 There's a lot of great tooling out there that'll not only help you build accessible websites, but also help you learn exactly what that means. 
 
@@ -66,4 +66,78 @@ export default AboutPage
 
 Whenever possible, it's good to maintain parity between the visual and audible experience of your app. That's just to say that `visuallyHidden` shouldn't be the first thing you reach for. But it's there if you need it!
 
-Note that if you have more than one `RouteAnnouncement`, Redwood uses the most specific one, that way if you have multiple layouts, you can override as needed.
+<!-- Note that if you have more than one `RouteAnnouncement`, Redwood uses the most specific one, that way if you have multiple layouts, you can override as needed. -->
+
+## Focus
+
+On page change, Redwood Router resets focus to the top of the DOM so that users can navigate through the new page. While this is the expected behavior (and the behavior you usually want), for some apps, especially those with a lot of navigation, it can be cumbersome for users to have tab through all that nav before getting to the main point. (And that goes for every page change!)
+
+Right now, there's two ways to alleviate this in Redwood: with skip links and/or the `RouteFocus` component.
+
+### Skip links
+
+Since the main content isn't usually the first thing on the page, it's a good practice to provide a shortcut for keyboard and screen-reader users to skip to it. Skip links do just that, and if you generate a layout (`yarn rw g layout`) with the `--skipLink` flag, you'll get a layout with a skip link:
+
+```terminal
+yarn rw g layout main --skipLink
+```
+
+```js
+import { SkipNavLink, SkipNavContent } from '@redwoodjs/router'
+import '@reach/skip-nav/styles.css'
+
+const MainLayout = ({ children }) => {
+  return (
+    <>
+      <SkipNavLink />
+      <nav></nav>
+      <SkipNavContent />
+      <main>{children}</main>
+    </>
+  )
+}
+
+export default MainLayout
+```
+
+`SkipNavLink` renders a link that remains hidden till focused; `SkipNavContent` renders a div as the target for the link. For more on these components, see the [Reach UI](https://reach.tech/skip-nav/#reach-skip-nav) docs.
+
+Making sure your navs have skip links is a great practice that goes a long way. And it really doesn't cost you much! 
+One thing you'll probably want to do is change the URL the skip link sends the user to when activated. You can do that by changing the `contentId` and `id` props of `SkipNavLink` and `SkipNavContent` respectively:
+
+```js
+<SkipNavLink contentId="main-content" />
+
+// ...
+
+<SkipNavContent id="main-content" />
+```
+
+If you'd prefer to implement your own skip link, [Ben Myers' blog](https://benmyers.dev/blog/skip-links/) is a great resource, and a great place to read about accessibility in general.
+
+### RouteFocus
+
+Sometimes you don't want to just skip the nav, but send a user somewhere. In this situation, you of course have the foresight that that place is where the user wants to be! So please use this at your discretion—sending a user to an unexpected location can be worse than sending them back the top.
+
+Having said that, if you know that on a particular page change a user's focus is better off being directed to a particular element, the `RouteFocus` component is what you want:
+
+```js
+import { RouteFocus } from '@redwoodjs/router'
+
+const ContactPage = () => (
+  <nav>
+    {/* way too much nav... */}
+  </nav>
+
+  // the contact form the user actually wants to interact with 
+  <RoueFocus>
+    <TextField name="name" />
+  </RoueFocus>
+)
+
+export default ContactPage
+```
+
+`RouteFocus` tells the router to send focus to it's child on page change. In the example above, when the user navigates to the contact page, the name text field on the form gets focus—the first field of the form they're here to fill out. 
+
+For a video exmaple of using `RouteFocus`, see our [meetup on Redwood's accessibility features](https://youtu.be/T1zs77LU68w?t=3240).

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -749,14 +749,15 @@ yarn redwood generate layout <name>
 
 Layouts wrap pages and help you stay DRY.
 
-| Arguments & Options  | Description                              |
-| :------------------- | :--------------------------------------- |
-| `name`               | Name of the layout                       |
-| `--force, -f`        | Overwrite existing files                 |
-| `--javascript, --js` | Generate JavaScript files                |
-| `--typescript, --ts` | Generate TypeScript files                |
-| `--tests`            | Generate test files [default: true]      |
-| `--stories`          | Generate Storybook files [default: true] |
+| Arguments & Options  | Description                                         |
+|----------------------|-----------------------------------------------------|
+| `name`               | Name of the layout                                  |
+| `--force, -f`        | Overwrite existing files                            |
+| `--javascript, --js` | Generate JavaScript files                           |
+| `--typescript, --ts` | Generate TypeScript files                           |
+| `--tests`            | Generate test files [default: true]                 |
+| `--stories`          | Generate Storybook files [default: true]            |
+| `--skipLink`         | Generate a layout with a skip link [default: false] |
 
 **Usage**
 


### PR DESCRIPTION
> https://deploy-preview-675--redwoodjs.netlify.app/docs/accessibility#focus

This PR updates documentation on how Redwood helps you manage focus in an accessible way with RouteFocus and skip links.