### PR TITLE
Document the changes to yarn rw serve

### DIFF
--- a/cookbook/Self-hosting_Redwood.md
+++ b/cookbook/Self-hosting_Redwood.md
@@ -1,49 +1,45 @@
-# Self-hosting Redwood: Serverfull
+# Self-hosting Redwood (Serverful)
 
-Do you prefer to host a Redwood app on your own server, the traditional serverfull way, instead of all this serverless magic? Well, you can! In this recipe we configure a Redwood app with PM2 and Nginx on a Linux server.
+Do you prefer hosting Redwood on your own server, the traditional serverful way, instead of all this serverless magic? Well, you can! In this recipe we configure a Redwood app with PM2 and Nginx on a Linux server.
 
-## Example
-
-A code example can be found at: https://github.com/njjkgeerts/redwood-pm2
-
-The example can be viewed live at: http://redwood-pm2.nickgeerts.com
+> A code example can be found at https://github.com/njjkgeerts/redwood-pm2, and can be viewed live at http://redwood-pm2.nickgeerts.com.
 
 ## Requirements
 
-You should have some basic knowledge of the following tools.
+You should have some basic knowledge of the following tools:
 
-- Linux
-- [Nginx](https://nginx.org/en/docs/)
-- [Postgres](https://www.postgresql.org/docs/)
 - [PM2](https://pm2.keymetrics.io/docs/usage/pm2-doc-single-page/)
-- Node
-- Yarn
+- [Nginx](https://nginx.org/en/docs/)
+- Linux
+- [Postgres](https://www.postgresql.org/docs/)
 
 ## Configuration
 
-### Project
+To self-host, you'll have to do a bit of configuration both to your Redwood app and your Linux server.
 
-Add Redwood's API server (in the API workspace) and PM2 (in the root with the -W flag) to your project.
+### Adding Dependencies
+
+First add PM2 as a dev depenency to your project root:
 
 ```termninal
-yarn workspace api add @redwoodjs/api-server
-yarn add -D pm2 -W
+yarn add -DW pm2
 ```
 
-Create a PM2 ecosystem configuration file. For clarity, it's recommended to rename `ecosystem.config.js` to something like `pm2.config.js`.
+Then create a PM2 ecosystem configuration file. For clarity, it's recommended to rename `ecosystem.config.js` to something like `pm2.config.js`:
 
 ```terminal
 yarn pm2 init
 mv ecosystem.config.js pm2.config.js
 ```
 
-Edit redwood.toml to change the API endpoint:
+Last but not least, change the API endpoint in `redwood.toml`:
 
-```toml
-apiProxyPath = "/api"
+```diff
+- apiProxyPath = "/.redwood/functions"
++ apiProxyPath = "/api"
 ```
 
-Optionally, add some scripts to your top-level package.json.
+Optionally, add some scripts to your top-level `package.json`:
 
 ```json
 "scripts": {
@@ -52,17 +48,17 @@ Optionally, add some scripts to your top-level package.json.
 }
 ```
 
+We'll refer to these later, so even if you don't add them to your project, keep them in mind.
+
 ### Linux server
 
-Your server should have a user for deployment, which should be configured with an SSH key pair providing access to your production environment. In this example, the user is named `deploy`.
+Your Linux server should have a user for deployment, configured with an SSH key providing access to your production environment. In this example, the user is named `deploy`.
 
 ### Nginx
 
-Your Nginx configuration file for the app should look something like this. Typically, this file would be stored at `/etc/nginx/sites-available/redwood-pm2` and is symbolically linked to `/etc/nginx/sites-enabled/redwood-pm2`.
+Typically, you keep your Nginx configuration file at `/etc/nginx/sites-available/redwood-pm2` and symlink it to `/etc/nginx/sites-enabled/redwood-pm2`. It should look something like this:
 
-Please note that the trailing slash in the proxy_pass value is essential to correctly map the API functions.
-
-```nginx
+```nginx{10}
 server {
   server_name redwood-pm2.example.com;
   listen 80;
@@ -82,9 +78,11 @@ server {
 }
 ```
 
+Please note that the trailing slash in `proxy_pass` is essential to correctly map the API functions.
+
 ### PM2
 
-The pm2.config.js file is used for PM2 settings. The most important variables are at the top. Note that the port is only used locally on the server and should match the port in the Nginx config.
+Let's configure PM2 with the `pm2.config.js` file we made earlier. The most important variables are at the top. Note that the port is only used locally on the server and should match the port in the Nginx config:
 
 ```javascript
 const name = 'redwood-pm2' // Name to use in PM2
@@ -101,8 +99,8 @@ module.exports = {
       name,
       node_args: '-r dotenv/config',
       cwd: `${path}/current/`,
-      script: 'node_modules/@redwoodjs/api-server/dist/index.js',
-      args: `-f api/dist/functions --port ${port}`,
+      script: 'yarn rw serve api',
+      args: '--port ${port}',
       env: {
         NODE_ENV: 'development',
       },
@@ -126,38 +124,32 @@ module.exports = {
 }
 ```
 
-> Note: if you need to seed tour production database during your first deployment, you'll need to add `&& yarn rw prisma db seed` to the end of your build command. But don't forget to remove it prior to subsequent deploys!
+If you need to seed your production database during your first deployment, you'll need to add `&& yarn rw prisma db seed` to the end of your build command. But don't forget to remove it prior to subsequent deploys!
 
-> Caveat: the API seems to only work in fork mode in PM2, not [cluster mode](https://pm2.keymetrics.io/docs/usage/cluster-mode/)
+> **Caveat:** the API seems to only work in fork mode in PM2, not [cluster mode](https://pm2.keymetrics.io/docs/usage/cluster-mode/).
 
 ## Deploying
 
-### Preparation
-
-First, we need to create the PM2 directories.
+First, we need to create the PM2 directories:
 
 ```terminal
 yarn install
 yarn deploy:setup
 ```
 
-Your server directories are now set. However, the `.env` settings are not yet configured. SSH into your server and create an `.env` file in the `current` subdirectory of the deploy directory.
+Your server directories are now set, but we haven't configured the `.env` settings yet. SSH into your server and create an `.env` file in the `current` subdirectory of the deploy directory:
 
 ```terminal
 vim /home/deploy/redwood-pm2/current/.env
 ```
 
-For example, add a DATABASE_URL variable.
+For example, add a `DATABASE_URL` variable:
 
 ```env
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/redwood-pm2
 ```
 
-Now we can finally deploy the app.
-
-### Actual deploy
-
-Just run the following. It should update the code, take care of database migrations and restart the app in PM2.
+Now we can deploy the app! Just run the following; it should update the code, take care of database migrations, and restart the app in PM2:
 
 ```terminal
 yarn deploy

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1521,16 +1521,40 @@ Run server for api in production, if you are self-hosting, or deploying into a s
 yarn redwood serve [side]
 ```
 
-<br>
+> You should run `yarn rw build` before running this command to make sure all the static assets that will be served have been built.
 
-| Arguments & Options | Description                                                                                                           |
-| :------------------ | :-------------------------------------------------------------------------------------------------------------------- |
-| `side`              | Which side(s) to run. Currently only supports `api`. Defaults to "api"                                                |
-| `--port`            | What port should the server run on [default: 8911]                                                                    |
-| `--socket`          | The socket the server should run. This takes precedence over port                                                     |
-| `--rootPath`        | The root path your api functions are served from i.e. localhost:`{port}`/`{rootPath}`/`{functionName}` [default: "/"] |
+`yarn rw serve` is useful for debugging locally or for self-hosting—deploying a single server into a serverful environment. Since both the api and the web sides run in the same server, CORS isn't a problem.
+
+| Arguments & Options | Description                                                                    |
+|---------------------|--------------------------------------------------------------------------------|
+| `side`              | Which side(s) to run. Choices are `api` and `web`. Defaults to `api` and `web` |
+| `--port`            | What port should the server run on [default: 8911]                             |
+| `--socket`          | The socket the server should run. This takes precedence over port              |
+
+### api
+
+Runs a server that only serves the api side.
+
+```
+yarn rw serve api
+```
+
+This command uses `apiProxyPath` in your `redwood.toml`. Use this command if you want to run just the api side on a server (e.g. running on Render).
 
 
+### web
+
+Runs a server that only serves the web side. 
+
+```
+yarn rw serve web
+```
+
+This command serves the contents in `web/dist`. Use this command if you're debugging (e.g. great for debuging prerender) or if you want to run your api and web sides on separate servers, which is often considered a best practice for scalability (since your api side likely has much higher scaling requirements).
+
+> **But shouldn't I use nginx and/or equivalent technology to serve static files?**
+>
+> Probably, but it can be a challenge to setup when you just want something running quickly!
 
 <br>
 

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1515,7 +1515,8 @@ yarn redwood test [side..]
 | `--clearCache`      | Delete the Jest cache directory and exit without running tests                                                                                                 |
 
 ## serve
-Run server for api in production, if you are self-hosting, or deploying into a serverfull environment.
+
+Runs a server that serves both the api and the web sides. 
 
 ```terminal
 yarn redwood serve [side]
@@ -1541,6 +1542,11 @@ yarn rw serve api
 
 This command uses `apiProxyPath` in your `redwood.toml`. Use this command if you want to run just the api side on a server (e.g. running on Render).
 
+| Arguments & Options | Description                                                       |
+|---------------------|-------------------------------------------------------------------|
+| `--port`            | What port should the server run on [default: 8911]                |
+| `--socket`          | The socket the server should run. This takes precedence over port |
+| `--apiRootPath`     | The root path where your api functions are served                 |
 
 ### web
 
@@ -1556,7 +1562,11 @@ This command serves the contents in `web/dist`. Use this command if you're debug
 >
 > Probably, but it can be a challenge to setup when you just want something running quickly!
 
-<br>
+| Arguments & Options | Description                                                                                  |
+|---------------------|----------------------------------------------------------------------------------------------|
+| `--port`            | What port should the server run on [default: 8911]                                           |
+| `--socket`          | The socket the server should run. This takes precedence over port                            |
+| `--apiHost`         | Forwards requests from the `apiProxyPath` (defined in `redwood.toml`) to the specified host  |
 
 ## upgrade
 


### PR DESCRIPTION
> https://deploy-preview-676--redwoodjs.netlify.app/docs/cli-commands#serve
> https://deploy-preview-676--redwoodjs.netlify.app/cookbook/self-hosting-redwood#project

This PR documents the changes to yarn rw serve (most notably, adding the ability to serve the web side).

Relevant PRs:
- https://github.com/redwoodjs/redwood/issues/2233
- https://github.com/redwoodjs/redwood/pull/2217
- https://github.com/redwoodjs/redwood/pull/2099

Docs to consider updating:
- cli commands — https://redwoodjs.com/docs/cli-commands#serve
- self-hosting redwood — https://redwoodjs.com/cookbook/self-hosting-redwood.html
- deploy — https://redwoodjs.com/docs/deploy
- prerender — https://redwoodjs.com/docs/prerender