### PR TITLE
chore(a11y): Corrects spelling of "example" in Accessibility docs

### DIFF
--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -140,4 +140,4 @@ export default ContactPage
 
 `RouteFocus` tells the router to send focus to it's child on page change. In the example above, when the user navigates to the contact page, the name text field on the form gets focus—the first field of the form they're here to fill out. 
 
-For a video exmaple of using `RouteFocus`, see our [meetup on Redwood's accessibility features](https://youtu.be/T1zs77LU68w?t=3240).
+For a video example of using `RouteFocus`, see our [meetup on Redwood's accessibility features](https://youtu.be/T1zs77LU68w?t=3240).


### PR DESCRIPTION
hey again! 