### PR TITLE
Adding JSON headers

### DIFF
--- a/docs/serverlessFunctions.md
+++ b/docs/serverlessFunctions.md
@@ -25,6 +25,9 @@ It'll give you a stub that exports a handler that returns a status code&mdash;th
 export const handler = async (event, context) => {
   return {
     statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({
       data: '${name} function',
     }),


### PR DESCRIPTION
It took me a while to figure out how to ensure that the response headers used 'Content-Type': 'application/json'. Maybe this addition to the docs will help others.