### PR TITLE
[v0.33] Redwood.toml config doc: add generate story | test options

### DIFF
--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -141,7 +141,7 @@ You can also provide the name of a browser to use instead of the system default.
 
 There's a lot more you can do here. For all the details, see Webpack's docs on [devServer.open](https://webpack.js.org/configuration/dev-server/#devserveropen).
 
-## generate
+## [generate]
 
 ```toml
 [generate]

--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -39,6 +39,10 @@ const DEFAULT_CONFIG: Config = {
   browser: {
     open: true,
   },
+  generate: {
+    tests: true,
+    stories: true,
+  },
 }
 ```
 
@@ -136,6 +140,21 @@ You can also provide the name of a browser to use instead of the system default.
 > When you generate a new app, the `open` value is set to `true`. If you delete the `open` config from `redwood.toml`, it will default to `false`. For example, removing the line `open = true` disables automatic browser opening.
 
 There's a lot more you can do here. For all the details, see Webpack's docs on [devServer.open](https://webpack.js.org/configuration/dev-server/#devserveropen).
+
+## generate
+
+```toml
+[generate]
+  tests = true
+  stories = true
+```
+
+Configuration for Generator "test" and "story" files. By default, the following Generators create Jest test and Storybook files (with mock data files when applicable) along with the specific component file(s): component, cell, layout, page, sdl, and services.
+
+| Key       | Description                    | Default  |
+| :-------- | :----------------------------- | :------- |
+| `tests`   | Generate Jest test files       | `true` |
+| `stories` | Generate Storybook story files | `true`   |
 
 ## Running within a Container or VM
 

--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -153,7 +153,7 @@ Configuration for Generator "test" and "story" files. By default, the following 
 
 | Key       | Description                    | Default  |
 | :-------- | :----------------------------- | :------- |
-| `tests`   | Generate Jest test files       | `true` |
+| `tests`   | Generate Jest test files       | `true`   |
 | `stories` | Generate Storybook story files | `true`   |
 
 ## Running within a Container or VM

--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -149,7 +149,7 @@ There's a lot more you can do here. For all the details, see Webpack's docs on [
   stories = true
 ```
 
-Configuration for Generator "test" and "story" files. By default, the following Generators create Jest test and Storybook files (with mock data files when applicable) along with the specific component file(s): component, cell, layout, page, sdl, and services.
+Configuration for Generator "test" and "story" files. By default, the following Generators create Jest test and/or Storybook files (with mock data files when applicable) along with specific component file(s): component, cell, layout, page, sdl, and services. Understandably, this is a lot of files, and sometimes you don't want all of them, either because you don't plan on using Jest/Storybook, or are just getting started and don't want the overhead. These toml keys allows you to toggle the generation of test and story files on and off.
 
 | Key       | Description                    | Default  |
 | :-------- | :----------------------------- | :------- |


### PR DESCRIPTION
**HOLD for v0.33 release**

Doc update for  https://github.com/redwoodjs/redwood/pull/1814

Adds [generate] config options to App Configuration.