### PR TITLE
Documents esbuild and apiproxy opts

### DIFF
--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -160,7 +160,7 @@ Setting to `true` creates stories for [Storybook](https://storybook.js.org/) whe
 
 ## [experimental]
 
-This section includes features that are *not stable* and maybe removed in future versions.
+This section includes features that are *not stable* and may be removed in future versions.
 
 ### esbuild
 

--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -15,7 +15,7 @@ You can configure your Redwood app's settings in `redwood.toml`. By default, `re
   open = true
 ```
 
-These are listed by default because they're the ones that you're most likely to configure. But there are plenty more available. The rest are spread between Redwood's [webpack configuration files](https://github.com/redwoodjs/redwood/tree/main/packages/core/config) and `@redwoodjs/internal`'s [config.ts](https://github.com/redwoodjs/redwood/blob/main/packages/internal/src/config.ts#L42-L60):
+These are listed by default because they're the ones that you're most likely to configure. But there are plenty more available. The rest are spread between Redwood's [webpack configuration files](https://github.com/redwoodjs/redwood/tree/main/packages/core/config) and `@redwoodjs/internal`'s [config.ts](https://github.com/redwoodjs/redwood/blob/main/packages/internal/src/config.ts#L54-L82):
 
 ```javascript
 // redwood/packages/internal/src/config.ts
@@ -27,18 +27,27 @@ const DEFAULT_CONFIG: Config = {
     path: './web',
     target: TargetEnum.BROWSER,
     apiProxyPath: '/.netlify/functions',
+    apiProxyPort: 8911,
     fastRefresh: true,
+    a11y: true,
   },
   api: {
     host: 'localhost',
     port: 8911,
     path: './api',
     target: TargetEnum.NODE,
-    schemaPath: './api/db/schema.prisma',
+    schemaPath: './api/prisma/schema.prisma',
   },
   browser: {
-    open: true,
+    open: false,
   },
+  generate: {
+    tests: true,
+    stories: true,
+  },
+  experimental: {
+    esbuild: false,
+  }
 }
 ```
 
@@ -71,8 +80,10 @@ Configuration for the web side.
 | `path`                        | Path to the web side               | `'./web'`               | `both`        |
 | `target`                      | Target for the web side            | `TargetEnum.BROWSER`    | `both`        |
 | `apiProxyPath`                | Proxy path to the api side         | `'/.netlify/functions'` | `production`  |
+| `apiProxyPort`                | Proxy port to the api side         | `8911`                  | `production`  |
 | `includeEnvironmentVariables` | Environment variables to whitelist |                         | `both`        |
 | `fastRefresh`                 | Enable webpack's fast refresh      | true                    | `development` |
+| `a11y`                        | Enable webpack's fast refresh      | true                    | `development` |
 
 ### apiProxyPath
 
@@ -136,6 +147,24 @@ You can also provide the name of a browser to use instead of the system default.
 > When you generate a new app, the `open` value is set to `true`. If you delete the `open` config from `redwood.toml`, it will default to `false`. For example, removing the line `open = true` disables automatic browser opening.
 
 There's a lot more you can do here. For all the details, see Webpack's docs on [devServer.open](https://webpack.js.org/configuration/dev-server/#devserveropen).
+
+## [generate]
+
+### Tests
+
+Setting to `true` creates tests when the generate command is invoked.
+
+### Stories
+
+Setting to `true` creates stories for [Storybook](https://storybook.js.org/) when the generate command is invoked.
+
+## [experimental]
+
+This section includes features that are *not stable* and maybe removed in future versions.
+
+### esbuild
+
+Setting to `true` will use [esbuild](https://esbuild.github.io/) instead of the Webpack for building the project.
 
 ## Running within a Container or VM
 

--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -36,7 +36,7 @@ const DEFAULT_CONFIG: Config = {
     port: 8911,
     path: './api',
     target: TargetEnum.NODE,
-    schemaPath: './api/prisma/schema.prisma',
+    schemaPath: './api/db/schema.prisma',
   },
   browser: {
     open: false,

--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -83,7 +83,7 @@ Configuration for the web side.
 | `apiProxyPort`                | Proxy port to the api side         | `8911`                  | `production`  |
 | `includeEnvironmentVariables` | Environment variables to whitelist |                         | `both`        |
 | `fastRefresh`                 | Enable webpack's fast refresh      | true                    | `development` |
-| `a11y`                        | Enable webpack's fast refresh      | true                    | `development` |
+| `a11y`                        | Enable storybook addon-a11y and eslint-plugin-jsx-a11y  | true                    | `development` |
 
 ### apiProxyPath
 


### PR DESCRIPTION
This updates the docs with current options available, including a new `esbuild` option which should be merged by https://github.com/redwoodjs/redwood/pull/2564