### PR TITLE
Add notes on purging unused Tailwind CSS

### DIFF
--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -231,13 +231,25 @@ yarn tailwindcss init
 
 This generates the tailwind config file, `tailwind.config.js`. Note that we'd ordinarily move this file to `web/config`, like we did with `postcss.config.js`. But since the Tailwind CSS IntelliSense won't work unless `tailwind.config.js` is in a base directory like `web`, we're just leaving this one here for now.
 
-Finally, use the tailwind directives in `web/src/index.css`
+Next, use the tailwind directives in `web/src/index.css`
 
 ```css
 /* ./web/src/index.css */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+```
+
+Optionally, you may also add file types to `purge` in your tailwind config file. This will remove unused tailwind CSS when building for production, reducing your css bundle size.
+```javascript
+// ./web/tailwind.config.js
+  purge: [
+    './src/**/*.html',
+    './src/**/*.jsx',
+    './src/**/*.js',
+    './src/**/*.ts',
+    './src/**/*.tsx',
+  ]
 ```
 
 And that should be it!

--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -243,13 +243,16 @@ Next, use the tailwind directives in `web/src/index.css`
 Optionally, you may also add file types to `purge` in your tailwind config file. This will remove unused tailwind CSS when building for production, reducing your css bundle size.
 ```javascript
 // ./web/tailwind.config.js
-  purge: [
-    './src/**/*.html',
-    './src/**/*.jsx',
-    './src/**/*.js',
-    './src/**/*.ts',
-    './src/**/*.tsx',
-  ]
+  purge: {
+    enabled: process.env.NETLIFY || process.env.NODE_ENV === 'production',
+    content: [
+      './src/**/*.html',
+      './src/**/*.js',
+      './src/**/*.jsx',
+      './src/**/*.tsx',
+      './src/**/*.ts',
+    ],
+  },
 ```
 
 And that should be it!


### PR DESCRIPTION
Adding notes on purging unused Tailwind CSS to the docs.
It's likely most people will want to purge unused Tailwind CSS when building for production as Tailwind is 3.6mb uncompressed (https://tailwindcss.com/docs/optimizing-for-production). 
For discussion: adding this to the default tailwind config