### PR TITLE
Corrects spelling of "arbitrary" in CLI Commands documentation

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1349,7 +1349,7 @@ Generating...
 ```
 
 ### generate script
-Generates an arbitary Node.js script in `./scripts/<name>` that can be used with `redwood execute` command later.
+Generates an arbitrary Node.js script in `./scripts/<name>` that can be used with `redwood execute` command later.
 
 | Arguments & Options  | Description                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------ |


### PR DESCRIPTION
Hey again. Subject says it all. 

All the best, 

António