### PR TITLE
Fixes link to secure services from GraphQL docs

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -225,7 +225,10 @@ The GraphQL Playground's nice, but if you're a power user, you'll want to be usi
 
 We'll document more GraphQL security best practices as Redwood reaches a `v1.0` release candidate. For now, know that Redwood already has some baked-in best practices; for example, when deploying GraphQL to production, GraphQL Playground is automatically disabled. 
 
-Some of the biggest security improvements we'll be making revolve around Services (which are intimately linked to GraphQL since they're wrapped into your resolvers). For `v1.0` we plan to make all of your resolvers secure by default. You can even opt into this behavior now—see the [Secure Services](/docs/services) section.
+
+### Secure Services
+
+Some of the biggest security improvements we'll be making revolve around Services (which are intimately linked to GraphQL since they're wrapped into your resolvers). For `v1.0` we plan to make all of your GraphQL resolvers secure by default. You can even opt into this behavior now—see the [Secure Services](https://redwoodjs.com/docs/services.html#secure-services) section.
 
 ## FAQ
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,7 +36,7 @@ For a demonstration, check out the [Auth Playground](https://redwood-playground-
 
 ## GraphQL
 
-GraphQL is a fundamental part of Redwood. For details on how Redwood uses GraphQL and handles important security considerations, please see the [GraphQL Security](/docs/graphql#security) section and the [Secure Services](docs/services#secure-services) section.
+GraphQL is a fundamental part of Redwood. For details on how Redwood uses GraphQL and handles important security considerations, please see the [GraphQL Security](/docs/graphql.html#security) section and the [Secure Services](/docs/services.html#secure-services) section.
 
 ## Functions
 


### PR DESCRIPTION
The link to the Secure Services docs section used a relative path and as such causes a 404 not found error.

This PR uses an absolute URL and makes a new section heading to highlight secure services as well in the TOC.