### PR TITLE
Logger documentation clarifies log level and adds Papertrail example

### DIFF
--- a/docs/logger.md
+++ b/docs/logger.md
@@ -396,16 +396,17 @@ export const logger = createLogger({
 
 * Install the [pino-papertrail](https://www.npmjs.com/package/pino-papertrail) package into `api`
 * Import `pino-papertrail`
-* Configure the `stream` in your Papertrail `options` with your project's configuration settings
+* Configure the `stream` in your Papertrail `options` with your appname's [configuration settings](https://github.com/ovhemert/pino-papertrail/blob/master/docs/API.md#options)
 * Set the logger `destination` to the `stream`
 
 ```js
 import papertrail from 'pino-papertrail'
 
-const stream = papertrail({
-   ...options,
-   appname: 'my-project'
- })
+const stream = papertrail.createWriteStream({
+  appname: 'my-app',
+  host: '*****.papertrailapp.com',
+  port: '*****',
+})```
 
 export const logger = createLogger({
   // options: {},

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -75,6 +75,9 @@ In addition to the rich [features](https://github.com/pinojs/pino/blob/master/do
 
 ### Log Level
 
+
+One of 'fatal', 'error', 'warn', 'info', 'debug', 'trace' or 'silent'.
+
 The logger detects you current environment and will default a sensible default minimum log level.
 
 > ***NOTE:*** In Development, the default is `trace` while in Production, the default is `warn`.
@@ -82,6 +85,7 @@ The logger detects you current environment and will default a sensible default m
 
 You can override the default log level via the `LOG_LEVEL` environment variable or the `level` LoggerOption.
 
+The 'silent' level disables logging.
 ### Troubleshooting
 
 > If you are not seeing log output when deployed, consider setting the level to `info` or `debug`.

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -110,6 +110,8 @@ import { createLogger } from '@redwoodjs/api/logger'
 export const logger = createLogger({ options: { level: 'info' } })
 ```
 
+Please refer to the [Pino options documentation](https://github.com/pinojs/pino/blob/master/docs/api.md#options) for a complete list.
+
 ### Redaction
 
 Everyone has herd or reports that Company X logged emails, or passwords to files or systems that may not have been secured. While RedwoodJS logging won't necessarily prevent that, it does provide you with the mechanism to ensure that won't happen.
@@ -234,7 +236,7 @@ RedwoodJS provides an opinionated logger with sensible, practical defaults. Thes
 Some examples of common configurations and overrides demonstrate how you can have control over both how and where you log.
 ### Override Log Level
 
-You can set the minimum level to log via the `level` option. This is useful if you need to override the default Production settings (just `warn` and `error`) to in this case `debug`.
+You can set the minimum [level](https://redwoodjs.com/docs/logger#log-level) to log via the `level` option. This is useful if you need to override the default Production settings (just `warn` and `error`) to in this case `debug`.
 
 ```js
 /**
@@ -394,12 +396,11 @@ export const logger = createLogger({
 
 * Install the [pino-papertrail](https://www.npmjs.com/package/pino-papertrail) package into `api`
 * Import `pino-papertrail`
-* Configure the `stream` with your Papertrail options
+* Configure the `stream` in your Papertrail `options` with your project's configuration settings
 * Set the logger `destination` to the `stream`
 
 ```js
 import papertrail from 'pino-papertrail'
-import options from './options.json'
 
 const stream = papertrail({
    ...options,

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -300,7 +300,7 @@ Note: logging to a file is not permitted if deployed to Netlify or Vercel.
  * Log to a File
  */
 export const logger = createLogger({
-  // options: {},
+  options: {},
   destination: '/path/to/file/api.log',
 })
 ```
@@ -340,10 +340,22 @@ yarn workspace api add pino-datadog
    size: 1,
  })
 
-// ...
-
+/**
+ * Creates a logger with RedwoodLoggerOptions
+ *
+ * These extend and override default LoggerOptions,
+ * can define a destination like a file or other supported pin log transport stream,
+ * and sets where or not to show the logger configuration settings (defaults to false)
+ *
+ * @param RedwoodLoggerOptions
+ *
+ * RedwoodLoggerOptions have
+ * @param {options} LoggerOptions - defines how to log, such as pretty printing, redaction, and format
+ * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
+ * @param {boolean} showConfig - whether to display logger configuration on initialization
+ */
 export const logger = createLogger({
-  // options: {},
+  options: {},
   destination: stream },
 })
 ```
@@ -374,7 +386,7 @@ export const stream = createWriteStream({
 })
 
 export const logger = createLogger({
-  // options: {},
+  options: {},
   destination: stream },
 })
 ```
@@ -400,8 +412,22 @@ const stream = pinoLogDna({
  , onError: console.error
  })
 
+/**
+ * Creates a logger with RedwoodLoggerOptions
+ *
+ * These extend and override default LoggerOptions,
+ * can define a destination like a file or other supported pin log transport stream,
+ * and sets where or not to show the logger configuration settings (defaults to false)
+ *
+ * @param RedwoodLoggerOptions
+ *
+ * RedwoodLoggerOptions have
+ * @param {options} LoggerOptions - defines how to log, such as pretty printing, redaction, and format
+ * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
+ * @param {boolean} showConfig - whether to display logger configuration on initialization
+ */
 export const logger = createLogger({
-  // options: {},
+  options: {},
   destination: stream },
 }) 
 ```
@@ -425,10 +451,24 @@ const stream = papertrail.createWriteStream({
   appname: 'my-app',
   host: '*****.papertrailapp.com',
   port: '*****',
-})```
+})
 
+/**
+ * Creates a logger with RedwoodLoggerOptions
+ *
+ * These extend and override default LoggerOptions,
+ * can define a destination like a file or other supported pin log transport stream,
+ * and sets where or not to show the logger configuration settings (defaults to false)
+ *
+ * @param RedwoodLoggerOptions
+ *
+ * RedwoodLoggerOptions have
+ * @param {options} LoggerOptions - defines how to log, such as pretty printing, redaction, and format
+ * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
+ * @param {boolean} showConfig - whether to display logger configuration on initialization
+ */
 export const logger = createLogger({
-  // options: {},
+  options: {},
   destination: stream },
 }) 
 ```

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -310,7 +310,12 @@ export const logger = createLogger({
 To stream your logs to [Datadog](https://www.datadoghq.com/), you can
 
 * Install the [`pino-datadog`](https://www.npmjs.com/package/pino-datadog) package into `api`
-* Import `pino-datadog`
+
+```terminal
+yarn workspace api add pino-datadog
+```
+
+* Import `pino-datadog` into `api/src/lib/logger.ts`
 * Configure the `stream` with your API key and [settings](https://github.com/ovhemert/pino-datadog/blob/master/docs/API.md)
 * Set the logger `destination` to the `stream`
 
@@ -318,6 +323,7 @@ To stream your logs to [Datadog](https://www.datadoghq.com/), you can
 /**
  * Stream logs to Datadog
  */
+ //`api/src/lib/logger.ts
  import datadog from 'pino-datadog'
  /**
   * Creates a synchronous pino-datadog stream
@@ -345,12 +351,13 @@ export const logger = createLogger({
 ### Log to Logflare using a Transport Stream Destination
 
 * Install the [`pino-logflare`](https://www.npmjs.com/package/pino-logflare) package into `api`
-* Import `pino-logflare`
+* Import `pino-logflare` into `api/src/lib/logger.ts`
 * Configure the `stream` with your [API key and sourceToken](https://github.com/Logflare/pino-logflare/blob/master/docs/API.md)
 * Set the logger `destination` to the `stream`
 
 
 ```js
+//`api/src/lib/logger.ts
 import { createWriteStream } from 'pino-logflare'
 
 /**
@@ -375,11 +382,17 @@ export const logger = createLogger({
 ### Log to logDNA using a Transport Stream Destination
 
 * Install the [pino-logdna](https://www.npmjs.com/package/pino-logdna) package into `api`
-* Import `pino-logdna`
+
+```terminal
+yarn workspace api add pino-logdna
+```
+
+* Import `pino-logdna` into `api/src/lib/logger.ts`
 * Configure the `stream` with your [ingestion key](https://github.com/Logflare/pino-logflare/blob/master/docs/API.md)
 * Set the logger `destination` to the `stream`
 
 ```js
+//`api/src/lib/logger.ts
 import pinoLogDna from 'pino-logdna'
 
 const stream = pinoLogDna({
@@ -395,7 +408,13 @@ export const logger = createLogger({
 ### Log to Papertrail using a Transport Stream Destination
 
 * Install the [pino-papertrail](https://www.npmjs.com/package/pino-papertrail) package into `api`
-* Import `pino-papertrail`
+
+
+```terminal
+yarn workspace api add pino-papertrail]
+```
+
+* Import `pino-papertrail` into `logger.ts`
 * Configure the `stream` in your Papertrail `options` with your appname's [configuration settings](https://github.com/ovhemert/pino-papertrail/blob/master/docs/API.md#options)
 * Set the logger `destination` to the `stream`
 

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -84,7 +84,7 @@ You can override the default log level via the `LOG_LEVEL` environment variable 
 
 ### Troubleshooting
 
-> If you are not seeing log out when deployed, consider setting the level to `info` or `debug`.
+> If you are not seeing log output when deployed, consider setting the level to `info` or `debug`.
 
 ```js
 import { createLogger } from '@redwoodjs/api/logger'


### PR DESCRIPTION
For Issue https://github.com/redwoodjs/redwood/issues/2901

@peterp needed some troubleshooting help when setting up [Papertrail logging](https://github.com/ovhemert/pino-papertrail).

The issue was that in production, the levels default to warn and above -- so that it is not too verbose -- and he was expecting to see some info or debug statements.

This PR clarifies this setting in troubleshooting.

Also, it stubs out the Papertail setup but needs to be confirmed by @peterp: Could you confirm that the setup instructions are ok? I didn't see any docs for an API key or what setting options are used. Or if the options were imported per the example ... or just defined in JSON.
