### PR TITLE
Clarify that the cli is ran locally in an app and not installed globally

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -15,7 +15,7 @@ A browser should automatically open to http://localhost:8910 and you will see th
 
 ## The Redwood CLI
 
-The Redwood developer experience relies heavily on the Redwood CLI.
+The Redwood developer experience relies heavily on the Redwood CLI. It's installed as a dependency when you create a new redwood-app, and is ran locally in your app.
 
 The following will show all the available commands in the Redwood CLI (note: rw is alias of redwood):
 ```


### PR DESCRIPTION
Just a doc fix, why the CLI can't be installed globally (or where it's installed from) was asked in chat by someone new to Redwood