### PR TITLE
Document GraphQL Handler configuration, logger options, and security measures

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -371,25 +371,10 @@ Here is an example of an application `/api/src/lib/logger.ts` configured to reda
 
 ```js
 // /api/src/lib/logger.ts
-import { createLogger } from '@redwoodjs/api/logger'
-import { redactionsList } from '@redwoodjs/api/logger'
-/**
- * Creates a logger with RedwoodLoggerOptions
- *
- * These extend and override default LoggerOptions,
- * can define a destination like a file or other supported pin log transport stream,
- * and sets where or not to show the logger configuration settings (defaults to false)
- *
- * @param RedwoodLoggerOptions
- *
- * RedwoodLoggerOptions have
- * @param {options} LoggerOptions - defines how to log, such as pretty printing, redaction, and format
- * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
- * @param {boolean} showConfig - whether to display logger configuration on initialization
- */
+import { createLogger, redactionsList } from '@redwoodjs/api/logger'
+
 export const logger = createLogger({
   options: {
-    prettyPrint: true,
     redact: [...redactionsList, 'email', 'data.users[*].email'],
   },
 })
@@ -401,14 +386,13 @@ Often you want to measure and report how long your queries take to execute and r
 
 You may turn on logging these metrics via the `tracing` GraphQL configuration option.
 
+```js
+// api/src/functions/graphql.ts
+// ...
+export const handler = createGraphQLHandler({
+  loggerConfig: { logger, options: { tracing: true } },
+// ...
 ```
-  /**
-   * @description Include the tracing and timing information.
-   *
-   * This will log various performance timings withing the GraphQL event lifecycle (parsing, validating, executing, etc).
-   */
-  tracing?: boolean
-  ```
 
 Let's say we wanted to get some benchmark numbers for the "find post by id" resolver
 
@@ -480,7 +464,7 @@ The [GraphQL Playground](https://github.com/graphql/graphql-playground) is a way
 
 Attackers often submit expensive, nested queries that could overload your database or expend costly resources.
 
-Typically, these types of  complex and expensive queries are usually huge deeply nested and take advantage of an understanding of your schema (hence why schema introspection is disabled byu default in production) and the data model relationships to create "cyclical" queries.
+Typically, these types of  complex and expensive queries are usually huge deeply nested and take advantage of an understanding of your schema (hence why schema introspection is disabled by default in production) and the data model relationships to create "cyclical" queries.
 
 Such unbounded GraphQL queries allow attackers to abuse query depth and with enough depth, this can easily impact your Graphql server and application.
 
@@ -514,15 +498,7 @@ query cyclical {
 
 > To mitigate the risk of attacking your application via deeply nested queries, RedwoodJS by default sets the [Query Depth Limit](https://www.npmjs.com/package/graphql-depth-limit#documentation) to 11. 
 
-If You would like to set the limit to a lower or higher limit, you may do so via the `depthLimitOptions` setting when creating your GraphQL handler.
-
-```
-  /**
-   * Limit the complexity of the queries solely by their depth.
-   * @see https://www.npmjs.com/package/graphql-depth-limit#documentation
-   */
-  depthLimitOptions?: DepthLimitOptions
-```
+You can change the default value via the `depthLimitOptions` setting when creating your GraphQL handler.
 
 You `depthLimitOptions` are `maxDepth` or `ignore` stops recursive depth checking based on a field name. Ignore can be [either a string or regexp]( https://www.npmjs.com/package/graphql-depth-limit#documentation) to match the name, or a function that returns a boolean.
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -256,8 +256,6 @@ export const handler = createGraphQLHandler({
 
 The `loggerConfig` takes several options that logs meaningful information along the graphQL execution lifecycle.
 
-TODO make into a table!
-
 
 |Option|Description|
 |:---|:---|
@@ -350,7 +348,6 @@ api |     }
 api |     query: "query ($id: Int!) {\n  post(id: $id) {\n    id\n    title\n    body\n    createdAt\n    publishedAt\n    updatedAt\n    __typename\n  }\n}\n"
 ```
 
-
 but keep your services concise!
 
 #### Send to Third-party Transports
@@ -380,7 +377,7 @@ export const logger = createLogger({
 })
 ```
 
-#### Timing Traces for Benchmarking Performances
+#### Timing Traces and Metrics
 
 Often you want to measure and report how long your queries take to execute and respond. You may already be measuring these durations at the database level, but you can also measure the time it takes for your the GraphQL server to parse, validate, and execute the request.
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -229,11 +229,7 @@ We want to make logging simple when using RedwoodJS and therefore have configure
 
 By configuring the GraphQL handler to use your api side [RedwoodJS logger](https://redwoodjs.com/docs/logger), any errors and other log statements about the [GraphQL execution](https://graphql.org/learn/execution/) will be logged to the [destination](https://redwoodjs.com/docs/logger#destination-aka-where-to-log) you've set up: to standard output, file, or transport stream.
 
-You configure the logger using the `loggerConfig` that accepts a [`logger`]((https://redwoodjs.com/docs/logger)) and s set of [GraphQL Logger Options](#graphql-logger-options):
-
-```js
-  loggerConfig: { logger, options: {} }
-```
+You configure the logger using the `loggerConfig` that accepts a [`logger`]((https://redwoodjs.com/docs/logger)) and s set of [GraphQL Logger Options](#graphql-logger-options).
 
 ### Configure the GraphQL Logger
 
@@ -459,11 +455,9 @@ The [GraphQL Playground](https://github.com/graphql/graphql-playground) is a way
 
 ### Query Depth Limit
 
-Attackers often submit expensive, nested queries that could overload your database or expend costly resources.
+Attackers often submit expensive, nested queries to abuse query depth that could overload your database or expend costly resources.
 
-Typically, these types of  complex and expensive queries are usually huge deeply nested and take advantage of an understanding of your schema (hence why schema introspection is disabled by default in production) and the data model relationships to create "cyclical" queries.
-
-Such unbounded GraphQL queries allow attackers to abuse query depth and with enough depth, this can easily impact your Graphql server and application.
+Typically, these types of unbounded, complex and expensive GraphQL queries are usually huge deeply nested and take advantage of an understanding of your schema (hence why schema introspection is disabled by default in production) and the data model relationships to create "cyclical" queries.
 
 An example of a cyclical query here takes advantage of knowing that and author has posts and each post has and author ... that has posts ... that has an another that ... etc.
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -241,28 +241,14 @@ A typical GraphQLHandler `graphql.ts` is as follows:
 
 ```js
 // api/src/functions/graphql.ts
+// ...
 
-import {
-  createGraphQLHandler,
-  makeMergedSchema,
-  makeServices,
-} from '@redwoodjs/api'
-
-import schemas from 'src/graphql/**/*.{js,ts}'
-import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
-import services from 'src/services/**/*.{js,ts}'
 
+// ...
 export const handler = createGraphQLHandler({
   loggerConfig: { logger, options: {} },
-  schema: makeMergedSchema({
-    schemas,
-    services: makeServices({ services }),
-  }),
-  onException: () => {
-    // Disconnect from your database with an unhandled exception.
-    db.$disconnect()
-  },
+// ...
 })
 ```
 
@@ -270,64 +256,17 @@ export const handler = createGraphQLHandler({
 
 The `loggerConfig` takes several options that logs meaningful information along the graphQL execution lifecycle.
 
-```js
-/**
- * Options for request and response information to include in the log statements
- * output by UseRedwoodLogger around the execution event
- *
- * @param data - Include response data sent to client.
- * @param operationName - Include operation name.
- * @param requestId - Include the event's requestId, or if none, generate a uuid as an identifier.
- * @param query - Include the query. This is the query or mutation (with fields) made in the request.
- * @param tracing - Include the tracing and timing information.
- * @param userAgent -Include the browser (or client's) user agent.
- */
-type GraphQLLoggerOptions = {
-  /**
-   * @description Include response data sent to client.
-   */
-  data?: boolean
+TODO make into a table!
 
-  /**
-   * @description Include operation name.
-   *
-   * The operation name is a meaningful and explicit name for your operation. It is only required in multi-operation documents,
-   * but its use is encouraged because it is very helpful for debugging and server-side logging.
-   * When something goes wrong (you see errors either in your network logs, or in the logs of your GraphQL server)
-   * it is easier to identify a query in your codebase by name instead of trying to decipher the contents.
-   * Think of this just like a function name in your favorite programming language.
-   *
-   * @see https://graphql.org/learn/queries/#operation-name
-   */
-  operationName?: boolean
 
-  /**
-   * @description Include the event's requestId, or if none, generate a uuid as an identifier.
-   *
-   * The requestId can be helpful when contacting your deployment provider to resolve issues when encountering errors or unexpected behavior.
-   */
-  requestId?: boolean
-
-  /**
-   * @description Include the query. This is the query or mutation (with fields) made in the request.
-   */
-  query?: boolean
-
-  /**
-   * @description Include the tracing and timing information.
-   *
-   * This will log various performance timings withing the GraphQL event lifecycle (parsing, validating, executing, etc).
-   */
-  tracing?: boolean
-
-  /**
-   * @description Include the browser (or client's) user agent.
-   *
-   * This can be helpful to know what type of client made the request to resolve issues when encountering errors or unexpected behavior.
-   */
-  userAgent?: boolean
-}
-```
+|Option|Description|
+|:---|:---|
+| data | Include response data sent to client. |
+| operationName | Include operation name. The operation name is a meaningful and explicit name for your operation. It is only required in multi-operation documents, but its use is encouraged because it is very helpful for debugging and server-side logging. When something goes wrong (you see errors either in your network logs, or in the logs of your GraphQL server) it is easier to identify a query in your codebase by name instead of trying to decipher the contents. Think of this just like a function name in your favorite programming language. See https://graphql.org/learn/queries/#operation-name
+|requestId| Include the event's requestId, or if none, generate a uuid as an identifier.
+|query|Include the query. This is the query or mutation (with fields) made in the request.
+| tracing |Include the tracing and timing information. This will ||log various performance timings withing the GraphQL event lifecycle (parsing, validating, executing, etc).
+|userAgent|Include the browser (or client's) user agent. This can be helpful to know what type of client made the request to resolve issues when encountering errors or unexpected behavior.
 
 Therefore, if you wish to log the GraphQL `query` made, the `data` returned, and the `operationName` used, you would
 
@@ -339,14 +278,7 @@ export const handler = createGraphQLHandler({
     logger,
     options: { data: true, operationName: true, query: true },
   },
-  schema: makeMergedSchema({
-    schemas,
-    services: makeServices({ services }),
-  }),
-  onException: () => {
-    // Disconnect from your database with an unhandled exception.
-    db.$disconnect()
-  },
+// ...
 })
 ```
 
@@ -386,7 +318,7 @@ export const handler = createGraphQLHandler({
 // ...
 ```
 
-then you do not need to log your `input` variables or the results in each service method.
+then you no longer have log your `input` variables or the results in each service method which can clean up your code.
 
 For example, instead of
 
@@ -466,7 +398,7 @@ Stream to third-party log and application monitoring services vital to productio
 
 #### Supports Log Redaction
 
-Everyone has herd or reports that Company X logged emails, or passwords to files or systems that may not have been secured. While RedwoodJS logging won't necessarily prevent that, it does provide you with the mechanism to ensure that won't happen.
+Everyone has heard of reports that Company X logged emails, or passwords to files or systems that may not have been secured. While RedwoodJS logging won't necessarily prevent that, it does provide you with the mechanism to ensure that won't happen.
 
 To redact sensitive information, you can supply paths to keys that hold sensitive data using the RedwoodJS logger [redact option](https://redwoodjs.com/docs/logger#redaction).
 
@@ -474,7 +406,7 @@ Because this logger is used with the GraphQL handler, it will respect any redact
 
 For example, you have chosen to log `data` return by each request, then you may want to redact sensitive information, like email addresses from yur logs.
 
-Here is an example of an application `/api/src/lib/logger.ts` confgured to redact email addresses. Take note of the path `data.users[*].email` as this says, in the `data` attribute, redact the `email` from every `user`:
+Here is an example of an application `/api/src/lib/logger.ts` configured to redact email addresses. Take note of the path `data.users[*].email` as this says, in the `data` attribute, redact the `email` from every `user`:
 
 ```js
 // /api/src/lib/logger.ts
@@ -559,61 +491,7 @@ api |             "returnType": "Int!",
 api |             "startOffset": 520982888,
 api |             "duration": 25140
 api |           },
-api |           {
-api |             "path": [
-api |               "post",
-api |               "title"
-api |             ],
-api |             "parentType": "Post",
-api |             "fieldName": "title",
-api |             "returnType": "String!",
-api |             "startOffset": 521023462,
-api |             "duration": 9168
-api |           },
-api |           {
-api |             "path": [
-api |               "post",
-api |               "body"
-api |             ],
-api |             "parentType": "Post",
-api |             "fieldName": "body",
-api |             "returnType": "String!",
-api |             "startOffset": 521042600,
-api |             "duration": 7028
-api |           },
-api |           {
-api |             "path": [
-api |               "post",
-api |               "createdAt"
-api |             ],
-api |             "parentType": "Post",
-api |             "fieldName": "createdAt",
-api |             "returnType": "DateTime!",
-api |             "startOffset": 521055959,
-api |             "duration": 8058
-api |           },
-api |           {
-api |             "path": [
-api |               "post",
-api |               "publishedAt"
-api |             ],
-api |             "parentType": "Post",
-api |             "fieldName": "publishedAt",
-api |             "returnType": "DateTime",
-api |             "startOffset": 521072409,
-api |             "duration": 5622
-api |           },
-api |           {
-api |             "path": [
-api |               "post",
-api |               "updatedAt"
-api |             ],
-api |             "parentType": "Post",
-api |             "fieldName": "updatedAt",
-api |             "returnType": "DateTime",
-api |             "startOffset": 521085620,
-api |             "duration": 5261
-api |           }
+... more paths follow ...
 api |         ]
 api |       }
 api |     }
@@ -690,28 +568,11 @@ You `depthLimitOptions` are `maxDepth` or `ignore` stops recursive depth checkin
 For example:
 
 ```js
-import {
-  createGraphQLHandler,
-  makeMergedSchema,
-  makeServices,
-} from '@redwoodjs/api'
-
-import schemas from 'src/graphql/**/*.{js,ts}'
-import { db } from 'src/lib/db'
-import { logger } from 'src/lib/logger'
-import services from 'src/services/**/*.{js,ts}'
-
+// ...
 export const handler = createGraphQLHandler({
   loggerConfig: { logger, options: { query: true } },
   depthLimitOptions: { maxDepth: 6 },
-  schema: makeMergedSchema({
-    schemas,
-    services: makeServices({ services }),
-  }),
-  onException: () => {
-    // Disconnect from your database with an unhandled exception.
-    db.$disconnect()
-  },
+// ...
 })
 
 ## FAQ

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -361,6 +361,19 @@ The [operation name](https://graphql.org/learn/queries/#operation-name) is a mea
 Because your cell typically has a unique operation name, logging this can help you identify which cell made a request.
 #### RequestId for Support Issue Resolution
 
+Often times, your deployment provider will provide a request identifier to help reconcile and track down problems at an infrastructure level. For example, AWS API GAteway and AWS Lambda (used by Netlify, for example) provides `requestId` on the `event`.
+
+You can include the request identifier setting the `requestId` logger option to `true`.
+
+```js
+// api/src/functions/graphql.ts
+// ...
+export const handler = createGraphQLHandler({
+  loggerConfig: { logger, options: { requestId: true } },
+// ...
+```
+
+And then, when working to resolve a support issue with your deployment provider, you can supply this request id to help them track down and investigate the problem more easily.
 #### No Need to Log within Services
 
 If you configure your GraphQL logger to include `data` and `query` information about each request adn its response as shown in:
@@ -370,7 +383,7 @@ If you configure your GraphQL logger to include `data` and `query` information a
 // ...
 export const handler = createGraphQLHandler({
   loggerConfig: { logger, options: { data: true, operationName: true, query: true } },
-/// ...
+// ...
 ```
 
 then you do not need to log your `input` variables or the results in each service method.

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -308,7 +308,7 @@ export const handler = createGraphQLHandler({
 And then, when working to resolve a support issue with your deployment provider, you can supply this request id to help them track down and investigate the problem more easily.
 #### No Need to Log within Services
 
-If you configure your GraphQL logger to include `data` and `query` information about each request adn its response as shown in:
+By configuring your GraphQL logger to include `data` and `query` information about each request you can keep your service implementation clean, concise and free of repeated logger statements in every resolver -- and still log the useful debugging information.
 
 ```js
 // api/src/functions/graphql.ts
@@ -316,57 +316,18 @@ If you configure your GraphQL logger to include `data` and `query` information a
 export const handler = createGraphQLHandler({
   loggerConfig: { logger, options: { data: true, operationName: true, query: true } },
 // ...
-```
 
-then you no longer have log your `input` variables or the results in each service method which can clean up your code.
-
-For example, instead of
-
-```js
-export const post = async ({ id }) => {
-  logger.debug({ id }, `Fetching post`)
-
-  const post = await db.post.findUnique({
-    where: { id },
-  })
-
-  logger.debug({ payload: post }, `Fetched post`)
-
-  return post
-}
-```
-
-that logs
-
-```terminal
-api | DEBUG [2021-07-09 14:17:03.030 +0000]: Fetching post
-api |     id: 2
-api | DEBUG [2021-07-09 14:17:03.385 +0000]: Fetched post
-api |     payload: {
-api |       "id": 2,
-api |       "createdAt": "2021-03-18T05:32:39.258Z",
-api |       "title": "Lime Tree Arbour",
-api |       "body": "The wind in the trees is whispering \\ Whispering low that I love her \\ She puts her hand over mine \\ Down in the lime tree arbour",
-api |       "authorId": null,
-api |       "editorId": "2458b7cf-9fef-4408-b4ab-ebaf2bacd0fa",
-api |       "publisherId": "2458b7cf-9fef-4408-b4ab-ebaf2bacd0fa",
-api |       "publishedAt": "2021-03-18T05:32:39.258Z",
-api |       "updatedAt": "2021-07-09T01:52:08.005Z"
-api |     }
-```
-
-you can configure operationName, data, and query log statements and  simplify your service to just be
-
-```js
+// api/src/services/posts.js
+//... 
 export const post = async ({ id }) => {
   return await db.post.findUnique({
     where: { id },
   })
 }
+//... 
 ```
 
-and output the same useful information (in a slightly different shape)
-
+The GraphQL handler take care of will then take take of logging  your query and data -- as long as your logger is setup to log at the `info` [level](https://redwoodjs.com/docs/logger#log-level) and above. You can also disable the statements in production by just logging at the `warn` and above [level](https://redwoodjs.com/docs/logger#log-level).
 
 ```terminal
 api | INFO [2021-07-09 14:20:11.656 +0000] (apollo-graphql-server): GraphQL requestDidStart

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -85,7 +85,7 @@ You can override the default log level via the `LOG_LEVEL` environment variable.
 
 ### Redaction
 
-Everyone has herd or reports that Company X logged emails, or passwords to files or systems that may not have been secured. While RedwoodJS logging won't necessarily prevent that, it does provide you with the mechanism to ensure that won't happen.
+Everyone has heard of reports that Company X logged emails, or passwords to files or systems that may not have been secured. While RedwoodJS logging won't necessarily prevent that, it does provide you with the mechanism to ensure that won't happen.
 
 To redact sensitive information, you can supply paths to keys that hold sensitive data using the [redact option](https://github.com/pinojs/pino/blob/master/docs/redaction.md).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -38,6 +38,12 @@ For a demonstration, check out the [Auth Playground](https://redwood-playground-
 
 GraphQL is a fundamental part of Redwood. For details on how Redwood uses GraphQL and handles important security considerations, please see the [GraphQL Security](/docs/graphql.html#security) section and the [Secure Services](/docs/services.html#secure-services) section.
 
+### Depth Limits
+
+The RedwoodJS GraphQL handler sets [reasonable defaults](/docs/graphql.html##query-depth-limit) to prevent deep, cyclical nested queries that attackers often use to exploit systems.
+### Disable Introspection and Playground
+
+Because both introspection and the playground share possibly sensitive information about your data model, your data, your queries and mutations, best practices for deploying a GraphQL Server call to [disable these in production](/docs/graphql.html#introspection-and-playground-disabled-in-production), RedwoodJS **only enables introspection and the playground when running in development**. 
 ## Functions
 
 When deployed, a [serverless function](/docs/serverless-functions) is an open API endpoint. That means anyone can access it and perform any tasks it's asked to do. In many cases, this is completely appropriate and desired behavior. But there are often times you need to restrict access to a function, and Redwood can help you do that using a [variety of methods and approaches](/docs/serverless-functions#security-considerations).


### PR DESCRIPTION
The PR documents the new options available when configuring the graphql server.

These settings -- including the GraphQL Logger Options - will be the same for both Apollo Server (current) and Helix/Envelop (future).

However, some log examples will need to be updated as the format of some query and trace timing output will be different when using envelop.

This Pr also documents some consideration in place to help secure the graphQL endpoint in development environments by disabling playground an introspection.

It also aims to inform the developer some benefits to using the GraphQL logger -- like keeping your services concise.

I did not go into plugin configuration or other Apollo Server graphql handler setup -- since this is best when transition to envelop and can do a more detailed discussion of the plugin ecosystem/

Closes #738