### PR TITLE
Documents how to customize and enrich the context in the GraphQL Handler

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -195,7 +195,7 @@ import { context } from '@redwoodjs/api
 
 Because the context is read-only in your services, if you need to modify it, then you need to do so in the `createGraphQLHandler`.
 
-To populate or enrich the context on a per-request basis with additional attributes, set a the `context` attribute `createGraphQLHandler` to a custom ContextFunction which modifies the context.
+To populate or enrich the context on a per-request basis with additional attributes, set the `context` attribute `createGraphQLHandler` to a custom ContextFunction that modifies the context.
 
 For example, if we want to populate a new, custom `ipAddress` attribute on the context with the information from the request's event, declare the `setIpAddress` ContextFunction as seen here:
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -234,6 +234,8 @@ export const handler = createGraphQLHandler({
 })
 ```
 
+> **Note:** If you use the preview GraphQL Helix/Envelop `graphql-server` package and a custom ContextFunction to modify the context in the createGraphQL handler, the function is provided ***only the context*** and ***not event***. However, the `event` information is available as an attribute of the context as `context.event`. Therefore, in the above example, one would fetch the ip address from the event this way: `ipAddress({ event: context.event })`.
+
 ### The Root Schema
 
 Did you know that you can query `redwood`? Try it in the GraphQL Playground (you can find the GraphQL Playground at http://localhost:8911/graphql when your dev server is running&mdash;`yarn rw dev api`):

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -191,7 +191,9 @@ In Redwood, the `context` object that's passed to resolvers is actually availabl
 import { context } from '@redwoodjs/api
 ```
 
-Note that when in your service (ie, a resolver) the context is read-only. If you need to modify the context, you need to do so in `createGraphQLHandler`.
+#### How to Modify the Context
+
+Because the context is read-only in your services, if you need to modify it, then you need to do so in the `createGraphQLHandler`.
 
 To populate or enrich the context on a per-request basis with additional attributes, set a the `context` attribute `createGraphQLHandler` to a custom ContextFunction which modifies the context.
 


### PR DESCRIPTION
As part of the GraphQL Helix / Envelop testing, it happens that customizing and populating the context in the GraphQL handler on a per-request basis using a custom ContextFunction changed.

In the api/Apollo version, the ContextFunction receives both the event and the context.

In envelop, a plugin has the just context, but the event information has been placed on the context already.

Therefore, if you had a function that used the event, one just now get the event from `context.event` when migrating to use `graphql-server`.

In order to describe this change in the Release Notes / Breaking Change / How to Upgrade section, there needs to be some existing documentation about how to enrich the context -- and this PR includes this info.