### PR TITLE
Explains why db seed is currently Javascript only and links how to use Typescript if so desired

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -300,6 +300,10 @@ yarn redwood prisma db seed
 
 Runs `seed.js` in `./api/db`. `seed.js` instantiates the Prisma client and provides an async main function where you can put any seed data&mdash;data that needs to exist for your app to run. See the [example blog's seed.js file](https://github.com/redwoodjs/example-blog/blob/master/api/db/seed.js).
 
+> **Note:** `db seed` is currently a [Prisma Preview Feature](https://www.prisma.io/docs/reference/api-reference/command-reference#db-seed-preview) and the RedwoodJS seed CLI command supports a Javascript `seed.js` file. If you wish to use Typescript,  please refer to [Seeding your database with TypeScript
+](https://www.prisma.io/docs/guides/database/seed-database/) in the Prisma documentation.
+
+
 ### db studio
 
 Start <a href="https://github.com/prisma/studio">Prisma Studio</a>, a visual editor for your database.

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -300,7 +300,7 @@ yarn redwood prisma db seed
 
 Runs `seed.js` in `./api/db`. `seed.js` instantiates the Prisma client and provides an async main function where you can put any seed data&mdash;data that needs to exist for your app to run. See the [example blog's seed.js file](https://github.com/redwoodjs/example-blog/blob/master/api/db/seed.js).
 
-> **Note:** `db seed` is currently a [Prisma Preview Feature](https://www.prisma.io/docs/reference/api-reference/command-reference#db-seed-preview) and the RedwoodJS seed CLI command supports a Javascript `seed.js` file. If you wish to use Typescript,  please refer to [Seeding your database with TypeScript
+> **Note:** The RedwoodJS seed CLI command supports a _Javascript_ `seed.js` file. If you wish to use Typescript, please refer to [Seeding your database with TypeScript
 ](https://www.prisma.io/docs/guides/database/seed-database/) in the Prisma documentation.
 
 


### PR DESCRIPTION
See: https://github.com/redwoodjs/redwood/pull/2553

Decide that only seed.js files supported.

This PR adds a message about supports JS only and includes a link to how to use Typescript if so desired.