### PR TITLE
Fix type-check typo and add it to CLI command doc

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1757,7 +1757,7 @@ yarn redwood test [side..]
 
 ## type-check
 
-Checks your TypeScript project for errors on both the api and the web sides.
+Runs a TypeScript compiler check on both the api and the web sides.
 
 ```terminal
 yarn redwood type-check [side]

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1755,6 +1755,24 @@ yarn redwood test [side..]
 
 > **Note** all other flags are passed onto the jest cli. So for example if you wanted to update your snapshots you can pass the `-u` flag
 
+## type-check
+
+Checks your TypeScript project for errors on both the api and the web sides.
+
+```terminal
+yarn redwood type-check [side]
+```
+
+<br/>
+
+| Arguments & Options | Description                                                                    |
+| ------------------- | ------------------------------------------------------------------------------ |
+| `side`              | Which side(s) to run. Choices are `api` and `web`. Defaults to `api` and `web` |
+
+**Usage**
+
+See [Running Type Checks](https://redwoodjs.com/docs/typescript#running-type-checks).
+
 ## serve
 
 Runs a server that serves both the api and the web sides.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -66,18 +66,18 @@ yarn rw setup tsconfig --force
 
 ## Running type checks
 
-Redwood uses Babel to transpile your TypeScript - which is why you are able to incrementally convert your project from JS to TS. However, it also means that just doing a build won't show you errors that the TypeScript compiler finds in your project <br/> <br/> That's why we have the handy `redwood typecheck` command!
+Redwood uses Babel to transpile your TypeScript - which is why you are able to incrementally convert your project from JS to TS. However, it also means that just doing a build won't show you errors that the TypeScript compiler finds in your project <br/> <br/> That's why we have the handy `redwood type-check` command!
 
 To check your TypeScript project for errors, run
 ```
-yarn rw typecheck
+yarn rw type-check
 ```
 This will run `tsc` on all the sides in your project, and make sure all the generated types are generated first, including Prisma.
 
 
 ### Check then build, on CI
 > **Tip!**<br/>
-> You don't need to build your project to run `rw typecheck`
+> You don't need to build your project to run `rw type-check`
 
 If your project is fully TypeScript, it might be useful to add typechecks before you run the deploy command in your CI.
 
@@ -86,7 +86,7 @@ For example, if you're deploying to Vercel, you could add a `build:ci` script to
 "scripts": {
   .
   .
-+  "build:ci": "yarn rw typecheck && yarn rw test --no-watch && yarn rw deploy vercel",
++  "build:ci": "yarn rw type-check && yarn rw test --no-watch && yarn rw deploy vercel",
 }
 ```
 Configure your project's build command to be `yarn build:ci` - and you even have your type checks and tests run whenever a pull request is opened!


### PR DESCRIPTION
Fix typo: `type-check` vs `typecheck`