### PR TITLE
Use example app name in TS docs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-`@redwoodjs/auth` contains both a build-in database-backed authentication system (dbAuth), as well as lightweight wrappers around popular SPA authentication libraries.
+`@redwoodjs/auth` contains both a built-in database-backed authentication system (dbAuth), as well as lightweight wrappers around popular SPA authentication libraries.
 
 We currently support the following third-party authentication providers:
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -4,7 +4,7 @@ Redwood comes with full TypeScript support out of the box, and you don't have to
 ## Starting a TypeScript Redwood project
 You can use the `--typescript` flag on create-redwood-app to generate a project with TypeScript configured:
 ```shell
-yarn create redwood-app --typescript /PATH/TO/FOLDER
+yarn create redwood-app --typescript my-redwood-app
 ```
 
 ## Converting an existing JS project to Typescript


### PR DESCRIPTION
It might be best to keep consistent with the Quickstart docs and use `my-redwood-app` as a concrete app name. I got a bit confused when reading `/PATH/TO/FOLDER` when getting started with the TS docs :)