### PR TITLE
Logger: Added a snippet for Honeybadger

### DIFF
--- a/docs/logger.md
+++ b/docs/logger.md
@@ -431,6 +431,52 @@ export const logger = createLogger({
   destination: stream },
 }) 
 ```
+### Log to Honeybadger using a Transport Stream Destination
+
+* Install the Honeybadger & Stream packages into `api`
+```shell
+yarn workspace api add @honeybadger-io/js stream
+```
+
+* Import `@honeybadger-io/js` `stream` into `logger.ts`
+```js
+import { createLogger } from '@redwoodjs/api/logger'
+import { Writable } from 'stream'
+
+const Honeybadger = require('@honeybadger-io/js')
+
+Honeybadger.configure({
+    apiKey: process.env.HONEYBADGER_API_KEY,
+})
+
+const HoneybadgerStream = () => {
+    const stream = new Writable({
+        write(
+            chunk: any,
+            encoding: BufferEncoding,
+            fnOnFlush: (error?: Error | null) => void
+        ) {
+            Honeybadger.notify(chunk.toString())
+            fnOnFlush()
+        },
+    })
+
+    return stream
+}
+
+
+/**
+ * Creates a logger. Options define how to log. Destination defines where to log.
+ * If no destination, std out.
+ */
+export const logger = createLogger({
+    options: { prettyPrint: true },
+    destination: HoneybadgerStream(),
+})
+```
+
+* Make sure you have a `HONEYBADGER_API_KEY` variable in your environment.
+
 ### Log to Papertrail using a Transport Stream Destination
 
 * Install the [pino-papertrail](https://www.npmjs.com/package/pino-papertrail) package into `api`

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -306,9 +306,8 @@ export const logger = createLogger({
 ```
 
 ### Customize your own Transport Stream Destination ( eg: Honeybadger.io )
-If Pino doesn't have a transport package for your service, you can write one with the class `Write` from the `stream` package. You can adapt this example to your own needs but here, we will use Honeybadger.io, which doesn't have an official pino transport package.
+If `pino` doesn't have a transport package for your service, you can write one with the class `Write` from the `stream` package. You can adapt this example to your own logging needs but here, we will use [Honeybadger.io](https://honeybadger.io).
 
-This example where we log to Honeybadger is an example of how to implement a custom logging solution.
 
 
 * Install the `stream` package into `api`
@@ -316,12 +315,12 @@ This example where we log to Honeybadger is an example of how to implement a cus
 yarn workspace api add stream
 ```
 
-* Install the `honeybadger-io/js` package into `api`, or any other package to suit your logging needs
+* Install the `honeybadger-io/js` package into `api`, or any other package that suits you
 ```shell
 yarn workspace api add @honeybadger-io/js
 ```
 
-* Import `@honeybadger-io/js` `stream` into `logger.ts`
+* Import both `stream` and `@honeybadger-io/js` into `api/src/lib/logger.ts`
 ```js
 import { createLogger } from '@redwoodjs/api/logger'
 import { Writable } from 'stream'
@@ -358,7 +357,9 @@ export const logger = createLogger({
 })
 ```
 
-* Make sure you have a `HONEYBADGER_API_KEY` variable in your environment.
+* For the sake of our example, make sure you have a `HONEYBADGER_API_KEY` variable in your environment.
+
+Documentation on the `Write` class can be found here: [https://nodejs.org/api/stream.html](https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback)
 
 ### Log to Datadog using a Transport Stream Destination
 

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -305,7 +305,7 @@ export const logger = createLogger({
 })
 ```
 
-### Customize your own Transport Stream Destination with Honeybadger
+### Customize your own Transport Stream Destination, eg: with Honeybadger
 
 If `pino` doesn't have a transport package for your service, you can write one with the class `Write` from the `stream` package. You can adapt this example to your own logging needs but here, we will use [Honeybadger.io](https://honeybadger.io).
 

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -305,7 +305,7 @@ export const logger = createLogger({
 })
 ```
 
-### Customize your own Transport Stream Destination ( eg: Honeybadger.io )
+### Customize your own Transport Stream Destination - with Honeybadger.io
 If `pino` doesn't have a transport package for your service, you can write one with the class `Write` from the `stream` package. You can adapt this example to your own logging needs but here, we will use [Honeybadger.io](https://honeybadger.io).
 
 

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -305,7 +305,7 @@ export const logger = createLogger({
 })
 ```
 
-### Customize your own Transport Stream Destination, with Honeybadger.io
+### Customize your own Transport Stream Destination with Honeybadger
 
 If `pino` doesn't have a transport package for your service, you can write one with the class `Write` from the `stream` package. You can adapt this example to your own logging needs but here, we will use [Honeybadger.io](https://honeybadger.io).
 

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -438,7 +438,7 @@ export const logger = createLogger({
 yarn workspace api add @honeybadger-io/js stream
 ```
 
-* Import `@honeybadger-io/js` `stream` into `logger.ts`
+* Import `@honeybadger-io/js` and `stream` into `logger.ts`
 ```js
 import { createLogger } from '@redwoodjs/api/logger'
 import { Writable } from 'stream'

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -305,7 +305,8 @@ export const logger = createLogger({
 })
 ```
 
-### Customize your own Transport Stream Destination - with Honeybadger.io
+### Customize your own Transport Stream Destination, with Honeybadger.io
+
 If `pino` doesn't have a transport package for your service, you can write one with the class `Write` from the `stream` package. You can adapt this example to your own logging needs but here, we will use [Honeybadger.io](https://honeybadger.io).
 
 


### PR DESCRIPTION
This PR adds a section in Logger to help anyone logging to Honeybadger.

Pino doesn't have - at least I haven't found any, a transport package for [Honeybadger](https://honeybadger.io), but we can write one with the class `Write` from the `stream` package. That can serve as a modest sample for anyone who'd want to implement a more custom logging solution.