### PR TITLE
SEO doc update for app title and title template 

### DIFF
--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -76,6 +76,7 @@ Configuration for the web side.
 
 | Key                           | Description                        | Default                 | Context       |
 | :---------------------------- | :--------------------------------- | :---------------------- | :------------ |
+| `title`                       | Title of your Redwood App          |                         | `both`        |
 | `host`                        | Hostname to listen on              | `'localhost'`           | `development` |
 | `port`                        | Port to listen on                  | `8910`                  | `development` |
 | `path`                        | Path to the web side               | `'./web'`               | `both`        |

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -34,7 +34,7 @@ _Examples  :_
 
 "%AppTitle · %PageTitle" = "Redwood App · Home Page"
 
-"%PageTitle : %AppTitle " = "Home Page : Redwood App"
+"%PageTitle : %AppTitle" = "Home Page : Redwood App"
 ```
 
 So now in your page you only need to write the title of the page.

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -30,11 +30,11 @@ You can write the format you like.
 
 _Examples  :_
 ```js
-"%PageTitle | %AppTitle" = "Home Page | Redwood App"
+"%PageTitle | %AppTitle" => "Home Page | Redwood App"
 
-"%AppTitle · %PageTitle" = "Redwood App · Home Page"
+"%AppTitle · %PageTitle" => "Redwood App · Home Page"
 
-"%PageTitle : %AppTitle" = "Home Page : Redwood App"
+"%PageTitle : %AppTitle" => "Home Page : Redwood App"
 ```
 
 So now in your page you only need to write the title of the page.

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -1,5 +1,41 @@
 # SEO & Meta tags
 
+## Add app title
+You certainly want to change the title of your Redwood app.
+You can start by adding or modify "title" inside `redwood.toml`
+
+```diff
+[web]
+- title = "Redwood App"
++ title = "My Cool App"
+  port = 8910
+  apiProxyPath = "/.redwood/functions"
+```
+This title (the app title) is used by default for all your pages if you don't define another one. 
+It will also be use for the title template ! 
+### Title template 
+Now that you have the app title set, you probably want some consistence with the page title, that's what the title template is for. 
+
+Add titleTemplate as a prop for RedwoodProvider to have a title template for every pages
+In _web/src/App.{tsx,js}_
+```diff
+-  <RedwoodProvider>
++  <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    /* ... */
+  <RedwoodProvider />
+```
+
+You can write the format you like. 
+_Example  :_
+```js
+"%PageTitle | %AppTitle" = "Home Page | Redwood App"
+
+"%AppTitle · %PageTitle" = "Redwood App · Home Page"
+
+"%AppTitle · %PageTitle" = "Redwood App · Home Page"
+```
+So now in your page you only need to write the title of the page.
+
 ## Adding to page `<head>`
 So you want to change the title of your page, or add elements to the `<head>` of the page? We've got you!
 
@@ -64,33 +100,6 @@ export default AboutPage
 ```
 
 This is great not just for link unfurling on say Facebook or Slack, but also for SEO. Take a look at the [source](https://github.com/redwoodjs/redwood/blob/main/packages/web/src/components/MetaTags.tsx#L83) if you're curious what tags get set here.
-
-## Adding app title
-
-Add "title" to redwood.toml to be globally use
-
-```toml
-[web]
-  title = "Redwood App"
-  port = 8910
-  apiProxyPath = "/.redwood/functions"
-```
-### Title template 
-
-add titleTemplate as prop for RedwoodProvider to have a title template for every pages
-
-```js
-// redwood/web/src/app.js
-  <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
-    /* ... */
-  <RedwoodProvider />
-  ```
-Exemple  : 
-
-%PageTitle | %AppTitle => Home Page | Redwood App
-
-%AppTitle · %PageTitle => Redwood App · Home Page
-
 
 
 ## Dynamic tags

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -27,14 +27,15 @@ In _web/src/App.{tsx,js}_
 ```
 
 You can write the format you like. 
-_Example  :_
-```js
-"%PageTitle | %AppTitle" = "Home Page | Redwood App"
 
-"%AppTitle · %PageTitle" = "Redwood App · Home Page"
+_Examples  :_
 
-"%AppTitle · %PageTitle" = "Redwood App · Home Page"
-```
+`"%PageTitle | %AppTitle" = "Home Page | Redwood App"`
+
+`"%AppTitle · %PageTitle" = "Redwood App · Home Page"`
+
+`"%PageTitle : %AppTitle " = "Home Page : Redwood App"`
+
 So now in your page you only need to write the title of the page.
 
 ## Adding to page `<head>`

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -2,7 +2,7 @@
 
 ## Add app title
 You certainly want to change the title of your Redwood app.
-You can start by adding or modify "title" inside `redwood.toml`
+You can start by adding or modify `title` inside `redwood.toml`
 
 ```diff
 [web]
@@ -11,12 +11,13 @@ You can start by adding or modify "title" inside `redwood.toml`
   port = 8910
   apiProxyPath = "/.redwood/functions"
 ```
-This title (the app title) is used by default for all your pages if you don't define another one. 
+This title (the app title) is used by default for all your pages if you don't define another one.
 It will also be use for the title template ! 
 ### Title template 
 Now that you have the app title set, you probably want some consistence with the page title, that's what the title template is for. 
 
-Add titleTemplate as a prop for RedwoodProvider to have a title template for every pages
+Add `titleTemplate` as a prop for `RedwoodProvider` to have a title template for every pages
+
 In _web/src/App.{tsx,js}_
 ```diff
 -  <RedwoodProvider>

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -29,12 +29,13 @@ In _web/src/App.{tsx,js}_
 You can write the format you like. 
 
 _Examples  :_
+```js
+"%PageTitle | %AppTitle" = "Home Page | Redwood App"
 
-`"%PageTitle | %AppTitle" = "Home Page | Redwood App"`
+"%AppTitle · %PageTitle" = "Redwood App · Home Page"
 
-`"%AppTitle · %PageTitle" = "Redwood App · Home Page"`
-
-`"%PageTitle : %AppTitle " = "Home Page : Redwood App"`
+"%PageTitle : %AppTitle " = "Home Page : Redwood App"
+```
 
 So now in your page you only need to write the title of the page.
 

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -53,6 +53,7 @@ const AboutPage = () => {
         ogUrl="https://awesomeredwoodapp.com/start"
         ogContentUrl="https://awesomeredwoodapp.com/static/og.png"
         robots={['nofollow']}
+        locale={}
       />
       <p className="font-light">This is the about page!</p>
     </div>
@@ -63,6 +64,33 @@ export default AboutPage
 ```
 
 This is great not just for link unfurling on say Facebook or Slack, but also for SEO. Take a look at the [source](https://github.com/redwoodjs/redwood/blob/main/packages/web/src/components/MetaTags.tsx#L83) if you're curious what tags get set here.
+
+## Adding app title
+
+Add "title" to redwood.toml to be globally use
+
+```toml
+[web]
+  title = "Redwood App"
+  port = 8910
+  apiProxyPath = "/.redwood/functions"
+```
+### Title template 
+
+add titleTemplate as prop for RedwoodProvider to have a title template for every pages
+
+```js
+// redwood/web/src/app.js
+  <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    /* ... */
+  <RedwoodProvider />
+  ```
+Exemple  : 
+
+%PageTitle | %AppTitle => Home Page | Redwood App
+
+%AppTitle · %PageTitle => Redwood App · Home Page
+
 
 
 ## Dynamic tags

--- a/docs/webpackConfiguration.md
+++ b/docs/webpackConfiguration.md
@@ -127,56 +127,13 @@ module.exports = {
 }
 ```
 
-Why choose one over another? There's a couple reasons: you can only configure a specific environment (i.e. development, production) using the first format. And as the [Changing the Title of the Page](#changing-the-title-of-the-page) example shows, you can also only modify existing rules using the first format.
+Why choose one over another? There's a couple reasons: you can only configure a specific environment (i.e. development, production) using the first format.
 
 If you're adding extras, the second format should work just fine. But by now you're already set up with the first so, unless you feel strongly, just go with that. -->
 
 ## Examples
 
 If you've never configured webpack before, here's some Redwood-specific examples to get you started.
-
-### Changing the Title of the Page
-
-By default, the title of the page will be the same as your app's base directory. For example, if your app's base directory is `redwood-app`, you'll see "redwood-app":
-
-![rw-wp-before](https://user-images.githubusercontent.com/32992335/83955148-b2b89c00-a804-11ea-92b5-55541f1b89aa.png)
-
-This is set in [webpack.common.js](https://github.com/redwoodjs/redwood/blob/34dd1a91516e7756ac6f9247a5d89c3adcbfdc2f/packages/core/config/webpack.common.js#L90):
-
-```js{4}
-// redwood/packages/core/config/webpack.common.js
-
-new HtmlWebpackPlugin({
-  title: path.basename(redwoodPaths.base),
-  template: path.resolve(redwoodPaths.base, 'web/src/index.html'),
-  inject: true,
-  chunks: 'all',
-}),
-```
-
-To change this, in your `web/config/webpack.config.js`, search `config`'s `plugins` array for `HtmlWebpackPlugin` and change it's `title` option:
-
-```javascript{6}
-// ./web/config/webpack.config.js
-
-module.exports = (config, { env }) => {
-  config.plugins.forEach((plugin) => {
-    if (plugin.constructor.name === 'HtmlWebpackPlugin') {
-      plugin.options.title = 'Some Custom Title'
-    }
-  })
-
-  return config
-}
-```
-
-Now, back in the browser, you'll see:
-
-![rw-wp-after](https://user-images.githubusercontent.com/32992335/83955150-bb10d700-a804-11ea-9c63-708bc2fe7139.png)
-
-> **Couldn't I just have done this in `web/index.html`?**
->
-> Yep. And you should. But hey, you're learning how to configure webpack over here!
 
 ### Adding Tailwind CSS
 


### PR DESCRIPTION
This add doc for app title and title template inside the SEO & Head page.
Also add title to app configuration

Related to : [#3026](https://github.com/redwoodjs/redwood/pull/3026)