### PR TITLE
Don't use pre-release version for latest release

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -213,14 +213,12 @@ const get = async (pathToFile) => {
 
 // gets latest released version from GitHub
 const getLatestVersion = async () => {
-  const response = await octokit.repos.listReleases({
+  const latestRelease = await octokit.repos.getLatestRelease({
     owner: 'redwoodjs',
     repo: 'redwood',
   })
 
-  const sortedReleases = response.data.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
-
-  const version = sortedReleases[0].tag_name
+  const version = latestRelease.data.tag_name
   console.info(`For version ${version}`)
   return version
 }


### PR DESCRIPTION
Uses `getLatestRelease` from Octokit than `listReleases` & sorting externally, which fetches the "most recent non-prerelease, non-draft release, sorted by the created_at attribute.". Docs: https://octokit.github.io/rest.js/v18#repos-get-latest-release

The major difference now being: 
>The created_at attribute is the date of the commit used for the release, and not the date when the release was drafted or published.

Which should be okay for our case.
_____
@thedavidprice @doesnotexist @simoncrypta I'd be glad to have you people review this PR. :)