### PR TITLE
Update docs/authentication firebase sections to match 0.37

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -10,7 +10,7 @@ We currently support the following third-party authentication providers:
 - [Clerk](https://clerk.dev)
 - [Netlify GoTrue-JS](https://github.com/netlify/gotrue-js)
 - [Magic Links - Magic.js](https://github.com/MagicHQ/magic-js)
-- [Firebase's GoogleAuthProvider](https://firebase.google.com/docs/reference/js/firebase.auth.GoogleAuthProvider)
+- [Firebase](https://firebase.google.com/docs/auth)
 - [Ethereum](https://github.com/oneclickdapp/ethereum-auth)
 - [Supabase](https://supabase.io/docs/guides/auth)
 - [Nhost](https://docs.nhost.io/auth)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1270,9 +1270,9 @@ Email/password authentication is supported by calling `login({ username, passwor
 
 #### Email link (passwordless sign-in ) in Firebase
 
-In Firebase Console, you must enable "Email link (passwordless sign-in)" with the configuration toggle under the email provider. The authenticaton sequence for passwordless email links has two steps:
+In Firebase Console, you must enable "Email link (passwordless sign-in)" with the configuration toggle for the email provider. The authenticaton sequence for passwordless email links has two steps:
 
-  - First, an email with the link must be generated and sent to the user.   Either using using firebase client sdk (web side) [sendSignInLinkToEmail](https://firebase.google.com/docs/reference/js/auth.emailauthprovider#example_2_2), which will generate and send the email to the user on your applications behalf or alternatively, generate the link using backend admin sdk (api side), see ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in) but it is then your responsibility to send an email to the user containing the link.
+  - First, an email with the link must be generated and sent to the user.   Either using using firebase client sdk (web side) [sendSignInLinkToEmail()](https://firebase.google.com/docs/reference/js/auth.emailauthprovider#example_2_2), which generates the link and sends the email to the user on behalf of your application or alternatively, generate the link using backend admin sdk (api side), see ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in) but it is then your responsibility to send an email to the user containing the link.
 
   - Second, authentication is completed when the user is redirected back to the application and the AuthProvider's logIn({emailLink, email, providerId: 'emailLink'}) method is called.
  

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -723,11 +723,13 @@ We're using [Firebase Google Sign-In](https://firebase.google.com/docs/auth/web/
 
 > **Including Environment Variables in Serverless Deployment:** in addition to adding the following env vars to your deployment hosting provider, you _must_ take an additional step to include them in your deployment build process. Using the names exactly as given below, follow the instructions in [this document](https://redwoodjs.com/docs/environment-variables) to "Whitelist them in your `redwood.toml`".
 
+
+
 ```js
 // web/src/App.js
 import { AuthProvider } from '@redwoodjs/auth'
-import * as firebase from 'firebase/app'
-import 'firebase/auth'
+import { initializeApp, getApps, getApp } from '@firebase/app'
+import * as firebaseAuth from '@firebase/auth'
 import { FatalErrorBoundary } from '@redwoodjs/web'
 import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
 
@@ -746,12 +748,18 @@ const firebaseClientConfig = {
   appId: process.env.FIREBASE_APP_ID,
 }
 
-const firebaseClient = ((config) => {
-  if (!firebase.apps.length) {
-    firebase.initializeApp(config)
+const firebaseApp = ((config) => {
+  const apps = getApps()
+  if (!apps.length) {
+    initializeApp(config)
   }
-  return firebase
-})(firebaseClientConfig)
+  return getApp()
+})(firebaseConfig)
+
+export const firebaseClient = {
+  firebaseAuth,
+  firebaseApp,
+}
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1270,9 +1270,9 @@ Email/password authentication is supported by calling `login({ username, passwor
 
 #### Email link (passwordless sign-in ) in Firebase
 
-In Firebase Console, you must enable "Email link (passwordless sign-in)" as configuration toggle under the email/password Sign-In Provider.  When using passwordless email links the authentication occurs in two-steps:
+In Firebase Console, you must enable "Email link (passwordless sign-in)" with the configuration toggle under the email provider. The authenticaton sequence for passwordless email links has two steps:
 
-  - First an email with the link must be generated and sent to the user.   Either using using firebase's client (web side) sdk [sendSignInLinkToEmail](https://firebase.google.com/docs/reference/js/auth.emailauthprovider#example_2_2), which will generate and send the email to the user on your applications behalf or alternatively, you can generate a link using backend (api side) admin sdk to generate a link, see ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in) but it is then your responsibility to send an email to the user containing the generated link.
+  - First, an email with the link must be generated and sent to the user.   Either using using firebase client sdk (web side) [sendSignInLinkToEmail](https://firebase.google.com/docs/reference/js/auth.emailauthprovider#example_2_2), which will generate and send the email to the user on your applications behalf or alternatively, generate the link using backend admin sdk (api side), see ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in) but it is then your responsibility to send an email to the user containing the link.
 
   - Second, authentication is completed when the user is redirected back to the application and the AuthProvider's logIn({emailLink, email, providerId: 'emailLink'}) method is called.
  
@@ -1287,8 +1287,8 @@ const EmailSigninPage = () => {
   const { loading, hasError, error, logIn } = useAuth()
 
   const email = window.localStorage.getItem('emailForSignIn')
-  // Prompt the user for email if its not available, in cases such as opening email link
-  // on a different device than from which email link authentication was initiated.
+  // TODO: Prompt the user for email if not found in local storage, for example
+  // if the user opened the email link on a different device.
 
   const emailLink = window.location.href
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1268,9 +1268,15 @@ Supported providers:
 
 Email/password authentication is supported by calling `login({ username, password })` and `signUp({ username, password })`.
 
-#### Passwordless Email Link Auth in Firebase
+#### Email Links (Passwordless) in Firebase
 
-Email links can be used for authentication with firebase.  See the ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in).  When a user clicks the login link they are first directed to firebase's backend and is completed on the application side at redirected url specified by actionCodes.url.  For example a dedicated route/page for completing email signin in your app to receive users at the actionCodes.url would use the AuthProvider's logIn() method:
+Email links authentication with firebase are also supported.  In this case Authentication is two-steps:
+
+  - First an email with the link must be generated and sent to the user.   Generate/send combined using firebase's client/web side sdk [sendSignInLinkToEmail](https://firebase.google.com/docs/reference/js/auth.emailauthprovider#example_2_2) or generate a link using backend/api side's admin sdk to generate a link, see ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in) which you must then send to a user yourself using an email service or SMTP server.
+
+  - Second, authentication is completed when the user is redirected back to the application and the AuthProvider's logIn({emailLink, email, providerId: 'emailLink'}) method is called.
+ 
+For example, users could be redirected to a dedicated route/page to complete authentication:
 
 ```js
 import { useEffect } from 'react'

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1272,9 +1272,8 @@ Email/password authentication is supported by calling `login({ username, passwor
 
 In Firebase Console, you must enable "Email link (passwordless sign-in)" with the configuration toggle for the email provider. The authenticaton sequence for passwordless email links has two steps:
 
-  - First, an email with the link must be generated and sent to the user.   Either using using firebase client sdk (web side) [sendSignInLinkToEmail()](https://firebase.google.com/docs/reference/js/auth.emailauthprovider#example_2_2), which generates the link and sends the email to the user on behalf of your application or alternatively, generate the link using backend admin sdk (api side), see ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in) but it is then your responsibility to send an email to the user containing the link.
-
-  - Second, authentication is completed when the user is redirected back to the application and the AuthProvider's logIn({emailLink, email, providerId: 'emailLink'}) method is called.
+  1. First, an email with the link must be generated and sent to the user.   Either using using firebase client sdk (web side) [sendSignInLinkToEmail()](https://firebase.google.com/docs/reference/js/auth.emailauthprovider#example_2_2), which generates the link and sends the email to the user on behalf of your application or alternatively, generate the link using backend admin sdk (api side), see ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in) but it is then your responsibility to send an email to the user containing the link.
+  2. Second, authentication is completed when the user is redirected back to the application and the AuthProvider's logIn({emailLink, email, providerId: 'emailLink'}) method is called.
  
 For example, users could be redirected to a dedicated route/page to complete authentication:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1268,6 +1268,47 @@ Supported providers:
 
 Email/password authentication is supported by calling `login({ username, password })` and `signUp({ username, password })`.
 
+#### Passwordless Email Link Auth in Firebase
+
+Email links can be used for authentication with firebase.  See the ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in).  When a user clicks the login link they are first directed to firebase's backend and is completed on the application side at redirected url specified by actionCodes.url.  For example a dedicated route/page for completing email signin in your app to receive users at the actionCodes.url would use the AuthProvider's logIn() method:
+
+```js
+import { useEffect } from 'react'
+import { Redirect, routes } from '@redwoodjs/router'
+import { useAuth } from '@redwoodjs/auth'
+
+const EmailSigninPage = () => {
+  const { loading, hasError, error, logIn } = useAuth()
+
+  const email = window.localStorage.getItem('emailForSignIn')
+  // Prompt the user for email if its not available, in cases such as opening email link
+  // on a different device than from which email link authentication was initiated.
+
+  const emailLink = window.location.href
+
+  useEffect(() => {
+    logIn({
+      providerId: 'emailLink',
+      email,
+      emailLink,
+    })
+  }, [])
+
+  if (loading) {
+    return <div>Auth Loading...</div>
+  }
+
+  if (hasError) {
+    console.error(error)
+    return <div>Auth Error... check console</div>
+  }
+
+  return <Redirect to={routes.home()} />
+}
+
+export default EmailSigninPage
+```
+
 #### Custom Parameters & Scopes for Google OAuth Provider
 
 Both `logIn()` and `signUp()` can accept a single argument of either a **string** or **object**. If a string is provided, it should be any of the supported providers (see above), which will configure the defaults for that provider.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1268,11 +1268,11 @@ Supported providers:
 
 Email/password authentication is supported by calling `login({ username, password })` and `signUp({ username, password })`.
 
-#### Email Links (Passwordless) in Firebase
+#### Email link (passwordless sign-in ) in Firebase
 
-Email links authentication with firebase are also supported.  In this case Authentication is two-steps:
+In Firebase Console, you must enable "Email link (passwordless sign-in)" as configuration toggle under the email/password Sign-In Provider.  When using passwordless email links the authentication occurs in two-steps:
 
-  - First an email with the link must be generated and sent to the user.   Generate/send combined using firebase's client/web side sdk [sendSignInLinkToEmail](https://firebase.google.com/docs/reference/js/auth.emailauthprovider#example_2_2) or generate a link using backend/api side's admin sdk to generate a link, see ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in) which you must then send to a user yourself using an email service or SMTP server.
+  - First an email with the link must be generated and sent to the user.   Either using using firebase's client (web side) sdk [sendSignInLinkToEmail](https://firebase.google.com/docs/reference/js/auth.emailauthprovider#example_2_2), which will generate and send the email to the user on your applications behalf or alternatively, you can generate a link using backend (api side) admin sdk to generate a link, see ["Generate email link for sign-in](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_link_for_sign-in) but it is then your responsibility to send an email to the user containing the generated link.
 
   - Second, authentication is completed when the user is redirected back to the application and the AuthProvider's logIn({emailLink, email, providerId: 'emailLink'}) method is called.
  


### PR DESCRIPTION
Bringing the official documentation up to date with firebase auth inr Redwood v0.37 and adding a sub-section for firebase email link authentication from https://github.com/redwoodjs/redwood/pull/3347