### PR TITLE
Docs / GraphQL - Adds health check request examples

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -302,7 +302,11 @@ If you need more than the default basic health check, you can provide a custom i
 
 const myCustomHealthCheck = async () => {
   if (ok) {
-    // replace with custom check
+    // Implement your custom check, such as:
+    // * invoke an api
+    // * call a service
+    // * make a db request
+    // that ensures your GraphQL endpoint is healthy
     return
   }
 
@@ -323,21 +327,34 @@ export const handler = createGraphQLHandler({
 
 To perform a health check, make a HTTP GET request to the `/graphql/health` endpoint.
 
-For local development, with the proxy:
+For local development, with the proxy using `curl` from the command line:
 
 ```bash
-~ % curl http://localhost:8911/graphql/health
-{"status":"pass"}%
+curl http://localhost:8911/graphql/health
 ```
 
-Directly invoking the graphql function:
+And you should get the response:
+
+``json
+{"status":"pass"}
+
+````
+
+Directly invoking the graphql function using `curl` from the command line:
 
 ```bash
-~ % curl http://localhost:8910/.redwood/functions/graphql/health
+curl http://localhost:8910/.redwood/functions/graphql/health
+````
+
+And you should get the response:
+
+```json
 {"status":"pass"}%
 ```
 
 For production or your deploy, make a request wherever your `/graphql` function exists.
+
+> Note: These examples use `curl`. You can performa a health check via any GET http request.
 
 ## Verifying GraphQL Schema
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -297,8 +297,7 @@ Health checks are used determine if a server is available and ready to start ser
 If you need more than the default basic health check, you can provide a custom implementation via an `onHealthCheck` function when creating the GraphQLHandler. If defined, this async `onHealthCheck` function should return if the server is deemed ready or throw if there is an error.
 
 ```ts
-// api/src/functions/graphql.ts
-/// ...
+// api/src/functions/graphql.{ts,js}
 
 const myCustomHealthCheck = async () => {
   if (ok) {
@@ -335,10 +334,9 @@ curl http://localhost:8911/graphql/health
 
 And you should get the response:
 
-``json
+```json
 {"status":"pass"}
-
-````
+```
 
 Directly invoking the graphql function using `curl` from the command line:
 
@@ -349,7 +347,7 @@ curl http://localhost:8910/.redwood/functions/graphql/health
 And you should get the response:
 
 ```json
-{"status":"pass"}%
+{"status":"pass"}
 ```
 
 For production or your deploy, make a request wherever your `/graphql` function exists.

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -326,25 +326,20 @@ export const handler = createGraphQLHandler({
 
 To perform a health check, make a HTTP GET request to the `/graphql/health` endpoint.
 
-For local development, with the proxy using `curl` from the command line:
+For local development, 
+with the proxy using `curl` from the command line:
+
+```bash
+curl http://localhost:8910/.redwood/functions/graphql/health
+```
+
+or by directly invoking the graphql function:
 
 ```bash
 curl http://localhost:8911/graphql/health
 ```
 
-And you should get the response:
-
-```json
-{"status":"pass"}
-```
-
-Directly invoking the graphql function using `curl` from the command line:
-
-```bash
-curl http://localhost:8910/.redwood/functions/graphql/health
-````
-
-And you should get the response:
+you should get the response:
 
 ```json
 {"status":"pass"}
@@ -352,7 +347,7 @@ And you should get the response:
 
 For production or your deploy, make a request wherever your `/graphql` function exists.
 
-> Note: These examples use `curl`. You can performa a health check via any GET http request.
+> Note: These examples use `curl` but you can performa a health check via any HTTP GET request.
 
 ## Verifying GraphQL Schema
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1,4 +1,4 @@
-# GraphQL 
+# GraphQL
 
 GraphQL is a fundamental part of Redwood. Having said that, you can get going without knowing anything about it, and can actually get quite far without ever having to read [the docs](https://graphql.org/learn/). But to master Redwood, you'll need to have more than just a vague notion of what GraphQL is; you'll have to really grok it.
 
@@ -52,10 +52,10 @@ const MutateButton = () => {
 
 Note that you're free to use any of Apollo's other hooks, you'll just have to import them from `@apollo/client` instead. In particular, these two hooks might come in handy:
 
-|Hook|Description|
-|:---|:---|
-|[useLazyQuery](https://www.apollographql.com/docs/react/api/react/hooks/#uselazyquery)|Execute queries in response to events other than component rendering|
-|[useApolloClient](https://www.apollographql.com/docs/react/api/react/hooks/#useapolloclient)|Access your instance of `ApolloClient`|
+| Hook                                                                                         | Description                                                          |
+| :------------------------------------------------------------------------------------------- | :------------------------------------------------------------------- |
+| [useLazyQuery](https://www.apollographql.com/docs/react/api/react/hooks/#uselazyquery)       | Execute queries in response to events other than component rendering |
+| [useApolloClient](https://www.apollographql.com/docs/react/api/react/hooks/#useapolloclient) | Access your instance of `ApolloClient`                               |
 
 ### Customizing the Apollo Client and Cache
 
@@ -92,7 +92,7 @@ As long as you're willing to do a bit of configuring yourself, you can swap out 
 - `useFetchConfig`
 - `GraphQLHooksProvider`
 
-For an example of configuring your own GraphQL Client, see the [redwoodjs-react-query-provider](https://www.npmjs.com/package/redwoodjs-react-query-provider). If you were thinking about using [react-query](https://react-query.tanstack.com/), you can also just go ahead and install it! 
+For an example of configuring your own GraphQL Client, see the [redwoodjs-react-query-provider](https://www.npmjs.com/package/redwoodjs-react-query-provider). If you were thinking about using [react-query](https://react-query.tanstack.com/), you can also just go ahead and install it!
 
 Note that if you don't import `RedwoodApolloProvider`, it won't be included in your bundle, dropping your bundle size quite a lot!
 
@@ -185,6 +185,7 @@ export const Users = {
 ### Redwood's Resolver Args
 
 [According to the spec](https://graphql.org/learn/execution/#root-fields-resolvers), resolvers take four arguments: `args`, `obj`, `context`, and `info`. In Redwood, resolvers do take these four arguments, but what they're named and how they're passed to resolvers is slightly different:
+
 - `args` is passed as the first argument
 - `obj` is named `root` (all the rest keep their names)
 - `root`, `context`, and `info` are wrapped into an object; this object is passed as the second argument
@@ -193,18 +194,18 @@ Here's an example to make things clear:
 
 ```javascript
 export const Post = {
-  user: (args, { root, context, info }) => db.post.findUnique({ where: { id: root.id } }).user()
+  user: (args, { root, context, info }) => db.post.findUnique({ where: { id: root.id } }).user(),
 }
 ```
 
 Of the four, you'll see `args` and `root` being used a lot.
 
-|Argument|Description|
-|:---|:---|
-|`args`|The arguments provided to the field in the GraphQL query|
-|`root`|The previous return in the resolver chain|
-|`context`|Holds important contextual information, like the currently logged in user|
-|`info`|Holds field-specific information relevant to the current query as well as the schema details|
+| Argument  | Description                                                                                  |
+| :-------- | :------------------------------------------------------------------------------------------- |
+| `args`    | The arguments provided to the field in the GraphQL query                                     |
+| `root`    | The previous return in the resolver chain                                                    |
+| `context` | Holds important contextual information, like the currently logged in user                    |
+| `info`    | Holds field-specific information relevant to the current query as well as the schema details |
 
 > **There's so many terms!**
 >
@@ -232,11 +233,7 @@ For example, if we want to populate a new, custom `ipAddress` attribute on the c
 // ...
 
 const ipAddress = ({ event }) => {
-  return (
-    event?.headers?.['client-ip'] ||
-    event?.requestContext?.identity?.sourceIp ||
-    'localhost'
-  )
+  return event?.headers?.['client-ip'] || event?.requestContext?.identity?.sourceIp || 'localhost'
 }
 
 const setIpAddress = async ({ event, context }) => {
@@ -261,7 +258,7 @@ export const handler = createGraphQLHandler({
 })
 ```
 
-> **Note:** If you use the preview GraphQL Helix/Envelop `graphql-server` package and a custom ContextFunction to modify the context in the createGraphQL handler, the function is provided ***only the context*** and ***not event***. However, the `event` information is available as an attribute of the context as `context.event`. Therefore, in the above example, one would fetch the ip address from the event this way: `ipAddress({ event: context.event })`.
+> **Note:** If you use the preview GraphQL Helix/Envelop `graphql-server` package and a custom ContextFunction to modify the context in the createGraphQL handler, the function is provided **_only the context_** and **_not event_**. However, the `event` information is available as an attribute of the context as `context.event`. Therefore, in the above example, one would fetch the ip address from the event this way: `ipAddress({ event: context.event })`.
 
 ### The Root Schema
 
@@ -293,18 +290,19 @@ The GraphQL Playground's nice, but if you're a power user, you'll want to be usi
 - dt has some thoughts on this
 - insomnia -->
 
-### Health checks
+### Health Checks
 
 Health checks are used determine if a server is available and ready to start serving traffic. By default, Redwood's GraphQLHandler provides a health check endpoint at `/graphql/health` which returns a `200 status code` with a result of `{ status: 'pass' }` if the server is healthy and can accept requests or a `503 status code` with `{ status: fail }` if not.
 
-If you need more than the default basic health check, you can provide a custom implementation via an `onHealthCheck` function when creating the GraphQLHandler. If defined, this async `onHealthCheck` function should return if the server is deemed ready or throw if there is an error. 
+If you need more than the default basic health check, you can provide a custom implementation via an `onHealthCheck` function when creating the GraphQLHandler. If defined, this async `onHealthCheck` function should return if the server is deemed ready or throw if there is an error.
 
 ```ts
 // api/src/functions/graphql.ts
 /// ...
 
 const myCustomHealthCheck = async () => {
-  if (ok) { // replace with custom check
+  if (ok) {
+    // replace with custom check
     return
   }
 
@@ -321,24 +319,43 @@ export const handler = createGraphQLHandler({
 })
 ```
 
+#### Perform a Health Check
+
+To perform a health check, make a HTTP GET request to the `/graphql/health` endpoint.
+
+For local development, with the proxy:
+
+```bash
+~ % curl http://localhost:8911/graphql/health
+{"status":"pass"}%
+```
+
+Directly invoking the graphql function:
+
+```bash
+~ % curl http://localhost:8910/.redwood/functions/graphql/health
+{"status":"pass"}%
+```
+
+For production or your deploy, make a request wherever your `/graphql` function exists.
+
 ## Verifying GraphQL Schema
 
 In order to keep your GraphQL endpoint and services secure, you must specify one of `@requireAuth`, `@skipAuth` or a custom directive on **every** query and mutation defined in your SDL.
 
 Redwood will verify that your schema complies with these runs when:
 
-* building (or building just the api)
-* launching the dev server.
+- building (or building just the api)
+- launching the dev server.
 
 If any fail this check, you will see:
 
-* each query of mutation listed in the command's error log
-* a fatal error `⚠️ GraphQL server crashed` if launching the server
+- each query of mutation listed in the command's error log
+- a fatal error `⚠️ GraphQL server crashed` if launching the server
 
 ### Build-time Verification
 
 When building via the `yarn rw build` command and the SDL fails verification, you will see output that lists each query or mutation missing the directive:
-
 
 ```terminal
   ✔ Generating Prisma Client...
@@ -356,7 +373,7 @@ You must specify one of @requireAuth, @skipAuth or a custom directive for
 - createContact Mutation
 - createPost Mutation
 - updatePost Mutation
-- deletePost Mutation 
+- deletePost Mutation
 ```
 
 ### Dev Server Verification
@@ -375,19 +392,19 @@ gen | 37 files generated
 api | Building... Took 444 ms
 api | Starting API Server... Took 2 ms
 api | Listening on http://localhost:8911/
-api | Importing Server Functions... 
+api | Importing Server Functions...
 web | ...
-api | FATAL [2021-09-24 18:41:49.700 +0000]: 
-api |  ⚠️ GraphQL server crashed 
-api | 
-api |     Error: You must specify one of @requireAuth, @skipAuth or a custom directive for 
+api | FATAL [2021-09-24 18:41:49.700 +0000]:
+api |  ⚠️ GraphQL server crashed
+api |
+api |     Error: You must specify one of @requireAuth, @skipAuth or a custom directive for
 api |     - contacts Query
 api |     - posts Query
 api |     - post Query
 api |     - createContact Mutation
 api |     - createPost Mutation
 api |     - updatePost Mutation
-api |     - deletePost Mutation 
+api |     - deletePost Mutation
 ```
 
 To fix these errors, simple declare with `@requireAuth` to enforce authentication or `@skipAuth` to keep the operation public on each as appropriate for your app's permissions needs.
@@ -398,7 +415,6 @@ Directives supercharge your GraphQL services. They add configuration to fields, 
 
 You'll recognize a directive by its preceded by the `@` character, e.g. `@myDirective`, and by being declared alongside a field:
 
-
 ```ts
 type Bar {
   name: String! @myDirective
@@ -406,7 +422,6 @@ type Bar {
 ```
 
 or a Query or Mutation:
-
 
 ```ts
 type Query {
@@ -417,6 +432,7 @@ type Mutation {
   createBar(input: CreateBarInput!): Bar! @myDirective
 }
 ```
+
 ### GraphQL Handler Setup
 
 Redwood makes it easy to code, organize, and map your directives into the GraphQL schema.
@@ -437,7 +453,7 @@ import { logger } from 'src/lib/logger'
 
 export const handler = createGraphQLHandler({
   loggerConfig: { logger, options: {} },
-  directives,//  👈 directives are added to the schema here
+  directives, //  👈 directives are added to the schema here
   sdls,
   services,
   onException: () => {
@@ -448,6 +464,7 @@ export const handler = createGraphQLHandler({
 ```
 
 > Note: Check-out the [in-depth look at Redwood Directives](https://www.redwoodjs.com/docs/directives) that explains how to generate directives so you may use them to validate access and transform the response.
+
 ## Logging
 
 Logging is essential in production apps to be alerted about critical errors and to be able to respond effectively to support issues. In staging and development environments, logging helps you debug queries, resolvers and cell requests.
@@ -456,7 +473,7 @@ We want to make logging simple when using RedwoodJS and therefore have configure
 
 By configuring the GraphQL handler to use your api side [RedwoodJS logger](https://redwoodjs.com/docs/logger), any errors and other log statements about the [GraphQL execution](https://graphql.org/learn/execution/) will be logged to the [destination](https://redwoodjs.com/docs/logger#destination-aka-where-to-log) you've set up: to standard output, file, or transport stream.
 
-You configure the logger using the `loggerConfig` that accepts a [`logger`]((https://redwoodjs.com/docs/logger)) and s set of [GraphQL Logger Options](#graphql-logger-options).
+You configure the logger using the `loggerConfig` that accepts a [`logger`](<(https://redwoodjs.com/docs/logger)>) and s set of [GraphQL Logger Options](#graphql-logger-options).
 
 ### Configure the GraphQL Logger
 
@@ -471,7 +488,7 @@ import { logger } from 'src/lib/logger'
 // ...
 export const handler = createGraphQLHandler({
   loggerConfig: { logger, options: {} },
-// ...
+  // ...
 })
 ```
 
@@ -479,15 +496,14 @@ export const handler = createGraphQLHandler({
 
 The `loggerConfig` takes several options that logs meaningful information along the graphQL execution lifecycle.
 
-
-|Option|Description|
-|:---|:---|
-| data | Include response data sent to client. |
-| operationName | Include operation name. The operation name is a meaningful and explicit name for your operation. It is only required in multi-operation documents, but its use is encouraged because it is very helpful for debugging and server-side logging. When something goes wrong (you see errors either in your network logs, or in the logs of your GraphQL server) it is easier to identify a query in your codebase by name instead of trying to decipher the contents. Think of this just like a function name in your favorite programming language. See https://graphql.org/learn/queries/#operation-name
-|requestId| Include the event's requestId, or if none, generate a uuid as an identifier.
-|query|Include the query. This is the query or mutation (with fields) made in the request.
-| tracing |Include the tracing and timing information. This will ||log various performance timings within the GraphQL event lifecycle (parsing, validating, executing, etc).
-|userAgent|Include the browser (or client's) user agent. This can be helpful to know what type of client made the request to resolve issues when encountering errors or unexpected behavior.
+| Option        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- | --------------------------------------------------------------------------------------------------------- |
+| data          | Include response data sent to client.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| operationName | Include operation name. The operation name is a meaningful and explicit name for your operation. It is only required in multi-operation documents, but its use is encouraged because it is very helpful for debugging and server-side logging. When something goes wrong (you see errors either in your network logs, or in the logs of your GraphQL server) it is easier to identify a query in your codebase by name instead of trying to decipher the contents. Think of this just like a function name in your favorite programming language. See https://graphql.org/learn/queries/#operation-name |
+| requestId     | Include the event's requestId, or if none, generate a uuid as an identifier.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| query         | Include the query. This is the query or mutation (with fields) made in the request.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| tracing       | Include the tracing and timing information. This will                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |     | log various performance timings within the GraphQL event lifecycle (parsing, validating, executing, etc). |
+| userAgent     | Include the browser (or client's) user agent. This can be helpful to know what type of client made the request to resolve issues when encountering errors or unexpected behavior.                                                                                                                                                                                                                                                                                                                                                                                                                       |
 
 Therefore, if you wish to log the GraphQL `query` made, the `data` returned, and the `operationName` used, you would
 
@@ -499,7 +515,7 @@ export const handler = createGraphQLHandler({
     logger,
     options: { data: true, operationName: true, query: true },
   },
-// ...
+  // ...
 })
 ```
 
@@ -512,6 +528,7 @@ Benefits of logging common GraphQL request information include debugging, profil
 The [operation name](https://graphql.org/learn/queries/#operation-name) is a meaningful and explicit name for your operation. It is only required in multi-operation documents, but its use is encouraged because it is very helpful for debugging and server-side logging.
 
 Because your cell typically has a unique operation name, logging this can help you identify which cell made a request.
+
 #### RequestId for Support Issue Resolution
 
 Often times, your deployment provider will provide a request identifier to help reconcile and track down problems at an infrastructure level. For example, AWS API Gateway and AWS Lambda (used by Netlify, for example) provides `requestId` on the `event`.
@@ -527,6 +544,7 @@ export const handler = createGraphQLHandler({
 ```
 
 And then, when working to resolve a support issue with your deployment provider, you can supply this request id to help them track down and investigate the problem more easily.
+
 #### No Need to Log within Services
 
 By configuring your GraphQL logger to include `data` and `query` information about each request you can keep your service implementation clean, concise and free of repeated logger statements in every resolver -- and still log the useful debugging information.
@@ -539,16 +557,16 @@ export const handler = createGraphQLHandler({
 // ...
 
 // api/src/services/posts.js
-//... 
+//...
 export const post = async ({ id }) => {
   return await db.post.findUnique({
     where: { id },
   })
 }
-//... 
+//...
 ```
 
-The GraphQL handler take care of will then take take of logging  your query and data -- as long as your logger is setup to log at the `info` [level](https://redwoodjs.com/docs/logger#log-level) and above. You can also disable the statements in production by just logging at the `warn` and above [level](https://redwoodjs.com/docs/logger#log-level).
+The GraphQL handler take care of will then take take of logging your query and data -- as long as your logger is setup to log at the `info` [level](https://redwoodjs.com/docs/logger#log-level) and above. You can also disable the statements in production by just logging at the `warn` and above [level](https://redwoodjs.com/docs/logger#log-level).
 
 ```terminal
 api | POST /graphql 200 7.754 ms - 1772
@@ -619,9 +637,9 @@ export const handler = createGraphQLHandler({
 Let's say we wanted to get some benchmark numbers for the "find post by id" resolver
 
 ```js
-  return await db.post.findUnique({
-    where: { id },
-  })
+return await db.post.findUnique({
+  where: { id },
+})
 ```
 
 We see that this request took about 500 msecs (note: duration is reported in nanoseconds).
@@ -665,10 +683,10 @@ api |     }
 ```
 
 By logging the operation name and extracting the duration for each query, you can easily collect and benchmark query performance.
+
 ## Security
 
-We'll document more GraphQL security best practices as Redwood reaches a `v1.0` release candidate. For now, know that Redwood already has some baked-in best practices; for example, when deploying GraphQL to production, GraphQL Playground is automatically disabled. 
-
+We'll document more GraphQL security best practices as Redwood reaches a `v1.0` release candidate. For now, know that Redwood already has some baked-in best practices; for example, when deploying GraphQL to production, GraphQL Playground is automatically disabled.
 
 ### Secure Services
 
@@ -716,11 +734,11 @@ query cyclical {
 }
 ```
 
-> To mitigate the risk of attacking your application via deeply nested queries, RedwoodJS by default sets the [Query Depth Limit](https://www.npmjs.com/package/graphql-depth-limit#documentation) to 11. 
+> To mitigate the risk of attacking your application via deeply nested queries, RedwoodJS by default sets the [Query Depth Limit](https://www.npmjs.com/package/graphql-depth-limit#documentation) to 11.
 
 You can change the default value via the `depthLimitOptions` setting when creating your GraphQL handler.
 
-You `depthLimitOptions` are `maxDepth` or `ignore` stops recursive depth checking based on a field name. Ignore can be [either a string or regexp]( https://www.npmjs.com/package/graphql-depth-limit#documentation) to match the name, or a function that returns a boolean.
+You `depthLimitOptions` are `maxDepth` or `ignore` stops recursive depth checking based on a field name. Ignore can be [either a string or regexp](https://www.npmjs.com/package/graphql-depth-limit#documentation) to match the name, or a function that returns a boolean.
 
 For example:
 
@@ -729,14 +747,15 @@ For example:
 export const handler = createGraphQLHandler({
   loggerConfig: { logger, options: { query: true } },
   depthLimitOptions: { maxDepth: 6 },
-// ...
+  // ...
 })
 ```
+
 ## FAQ
 
 ### Why Doesn't Redwood Use Something Like Nexus?
 
-This might be one of our most frequently asked questions of all time. Here's [Tom's response in the forum](https://community.redwoodjs.com/t/anyone-playing-around-with-nexus-js/360/5): 
+This might be one of our most frequently asked questions of all time. Here's [Tom's response in the forum](https://community.redwoodjs.com/t/anyone-playing-around-with-nexus-js/360/5):
 
 > We started with Nexus, but ended up pulling it out because we felt like it was too much of an abstraction over the SDL. It’s so nice being able to just read the raw SDL to see what the GraphQL API is.
 


### PR DESCRIPTION
Fixes: https://github.com/redwoodjs/redwoodjs.com/issues/860

The documentation wasn't clear that the health check was a GET request.

Some people were trying to request a health check via a GraphQL POST.

Added a few examples to make that better understood.
