### PR TITLE
doc: Fix Email & Password Auth in Firebase options

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1301,7 +1301,7 @@ Supported providers:
 
 #### Email & Password Auth in Firebase
 
-Email/password authentication is supported by calling `login({ username, password })` and `signUp({ username, password })`.
+Email/password authentication is supported by calling `login({ email, password })` and `signUp({ email, password })`.
 
 #### Email link (passwordless sign-in) in Firebase
 


### PR DESCRIPTION
Email & Password Auth in Firebase options should be email and password, not username and password