### PR TITLE
Fixed CLI option for "allow host" for webpack 5

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -197,10 +197,10 @@ Using `--forward` (alias `--fwd`), you can pass one or more Webpack Dev Server [
 ~/redwood-app$ yarn redwood dev --fwd="--port=1234 --open=false"
 ```
 
-You may need to access your dev application from a different host, like your mobile device. To resolve the “Invalid Host Header” message, run the following:
+You may need to access your dev application from a different host, like your mobile device or an SSH tunnel. To resolve the “Invalid Host Header” message, run the following:
 
 ```bash
-~/redwood-app$ yarn redwood dev --fwd="--disable-host-check"
+~/redwood-app$ yarn redwood dev --fwd=\"--allowed-hosts all\"
 ```
 
 For the full list of Webpack Dev Server settings, see [this documentation](https://webpack.js.org/configuration/dev-server/).

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -200,7 +200,7 @@ Using `--forward` (alias `--fwd`), you can pass one or more Webpack Dev Server [
 You may need to access your dev application from a different host, like your mobile device or an SSH tunnel. To resolve the “Invalid Host Header” message, run the following:
 
 ```bash
-~/redwood-app$ yarn redwood dev --fwd=\"--allowed-hosts all\"
+~/redwood-app$ yarn redwood dev --fwd="--allowed-hosts all"
 ```
 
 For the full list of Webpack Dev Server settings, see [this documentation](https://webpack.js.org/configuration/dev-server/).


### PR DESCRIPTION
The documentation for allowed all hosts did not match webpack 5. New webpack option is: `--allowed-hosts all`. Updated accordingly.

Also added text to explain that this option is needed for SSH tunneling, such as ngrok or localhost.run.
