### PR TITLE
Fix docs for `excludeOperations` logger option

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -582,6 +582,43 @@ export const handler = createGraphQLHandler({
 })
 ```
 
+#### Exclude Operations
+
+You can exclude GraphQL operations by name with `excludeOperations`.
+This is useful when you want to filter out certain operations from the log output, for example, `IntrospectionQuery` from GraphQL playground:
+
+```js{5}
+// api/src/functions/graphql.ts
+export const handler = createGraphQLHandler({
+  loggerConfig: {
+    logger,
+    options: { excludeOperations: ['IntrospectionQuery'] },
+  },
+  directives,
+  sdls,
+  services,
+  onException: () => {
+    // Disconnect from your database with an unhandled exception.
+    db.$disconnect()
+  },
+})
+```
+
+> **Relevant anatomy of an operation**
+>
+> In the example below, `"FilteredQuery"` is the operation's name.
+> That's what you'd  pass to `excludeOperations` if you wanted it filtered out.
+>
+> ```js
+> export const filteredQuery = `
+>   query FilteredQuery {
+>     me {
+>       id
+>       name
+>     }
+>   }
+> ```
+
 ### Benefits of Logging
 
 Benefits of logging common GraphQL request information include debugging, profiling, and resolving issue reports.

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -216,44 +216,6 @@ See below for examples of how to configure Logflare and Datadog.
 
 Note that not all [known pino transports](https://github.com/pinojs/pino/blob/HEAD/docs/transports.md#known-transports) can be used in a serverless environment.
 
-### Exclude Operations
-
-You can exclude GraphQL operations by name with `excludeOperations`.
-This is useful when you want to filter out certain operations from the log output, for example, `IntrospectionQuery` from GraphQL playground:
-
-```js{5}
-// api/src/functions/graphql.{ts|js}
-export const handler = createGraphQLHandler({
-  loggerConfig: {
-    logger,
-    options: { excludeOperations: ['IntrospectionQuery'] },
-  },
-  directives,
-  sdls,
-  services,
-  onException: () => {
-    // Disconnect from your database with an unhandled exception.
-    db.$disconnect()
-  },
-})
-```
-
-> **Relevant anatomy of an operation**
->
-> In the example below, `"FilteredQuery"` is the operation's name.
-> That's what you'd  pass to `excludeOperations` if you wanted it filtered out.
->
-> ```js
-> export const filteredQuery = `
->   query FilteredQuery {
->     me {
->       id
->       name
->     }
->   }
-> `
-> ```
-
 ## Default Configuration Overview
 
 RedwoodJS provides an opinionated logger with sensible, practical defaults. These include:

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -221,12 +221,21 @@ Note that not all [known pino transports](https://github.com/pinojs/pino/blob/HE
 You can exclude GraphQL operations by name with `excludeOperations`.
 This is useful when you want to filter out certain operations from the log output, for example, `IntrospectionQuery` from GraphQL playground:
 
-```js
-const logger = createLogger({
-  options: {
-    excludeOperations: ['IntrospectionQuery'],
+```js{5}
+// api/src/functions/graphql.{ts|js}
+export const handler = createGraphQLHandler({
+  loggerConfig: {
+    logger,
+    options: { excludeOperations: ['IntrospectionQuery'] },
   },
-)
+  directives,
+  sdls,
+  services,
+  onException: () => {
+    // Disconnect from your database with an unhandled exception.
+    db.$disconnect()
+  },
+})
 ```
 
 > **Relevant anatomy of an operation**


### PR DESCRIPTION
Thanks to @KrisCoulson: https://github.com/redwoodjs/redwoodjs.com/pull/863#discussion_r754798353.

Like Kris suggested I've updated the docs, and also moved it to the GraphQL page instead of where other Graphql logging options docs are. 