### PR TITLE
add windows setup to cookbook

### DIFF
--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -1,0 +1,57 @@
+# Windows Development Setup
+
+This guide provides a simple setup to start developing a RedwoodJS project on Windows. Many setup options exist, but this aims to make getting started as easy as possible. This is the recommended setup unless you have experience with other shell like PowerShell. 
+
+> If you're interested in using the Windows Subsystem for Linux instead, there is a [community guide for that](https://community.redwoodjs.com/t/windows-subsystem-for-linux-setup/2439).
+
+### **Git Bash**
+
+Download the last release of [**Git for Windows**](https://git-scm.com/download/win) and install it. 
+When installing Git, you can add the icon on the Desktop and add Git Bash profile to Windows Terminal if you use it, but it is optional. 
+
+![1-git components.png](Windows%20setup%20for%20Redwood%20aa3e6e732a8440708763a609984ce495/1-git_components.png)
+
+Next, set VS Code as Git default editor (or default for the editor you use). 
+
+![2-git editor.png](Windows%20setup%20for%20Redwood%20aa3e6e732a8440708763a609984ce495/2-git_editor.png)
+
+For every other step, we recommended keeping to the default choice.
+
+### **Node.js environment (and npm)**
+
+We recommend you install the latest `nvm-setup.zip` of [**nvm-windows**](https://github.com/coreybutler/nvm-windows/releases) to manage multiple version installations of Node.js. When the installation of nvm is complete, run Git Bash as administrator to install Node with npm. 
+
+![3- git run as admin.png](Windows%20setup%20for%20Redwood%20aa3e6e732a8440708763a609984ce495/3-_git_run_as_admin.png)
+
+Redwood uses the LTS version of Node. To install, run the following commands inside the terminal: 
+
+```bash
+$ nvm install lts --latest-npm
+// installs latest LTS and npm; e.g. 16.13.1 for the following examples
+$ nvm use 16.13.1
+```
+
+### Yarn
+
+Now you have both Node and npm installed! Redwood also uses yarn, which you can now install using npm:
+
+```bash
+ npm install -g yarn
+```
+
+*Example of Node.js, npm, and Yarn installation steps*
+
+![4.1-install yarn.png](Windows%20setup%20for%20Redwood%20aa3e6e732a8440708763a609984ce495/4.1-install_yarn.png)
+
+## **Congrats**!
+
+You now have everything ready to build your Redwood app. Just run:
+
+```bash
+yarn create redwood-app ./myApp 
+```
+
+Next, you should start the amazing [**Redwood Tutorial**](https://learn.redwoodjs.com/docs/tutorial/installation-starting-development) to learn how to use the framework. 
+
+>⚠️ Heads Up  
+On Windows Git Bash, `cd dev` and `cd Dev` will select the same directory because Windows is case-insensitive. But make sure you type the original capitalization to avoid strange errors in your Redwood project.

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -15,7 +15,7 @@ Next, set VS Code as Git default editor (or pick any other editor you're comfort
 
 ![2-git_editor.png](https://user-images.githubusercontent.com/18013532/146685299-0e067554-a5a8-46b9-91ac-ffcd6f738b80.png)
 
-For all other steps, we recommended keeping to the default choices.
+For all other steps, we recommended keeping the default choices.
 
 ### Node.js environment (and npm)
 

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -9,11 +9,11 @@ This guide provides a simple setup to start developing a RedwoodJS project on Wi
 Download the last release of [**Git for Windows**](https://git-scm.com/download/win) and install it. 
 When installing Git, you can add the icon on the Desktop and add Git Bash profile to Windows Terminal if you use it, but it is optional. 
 
-![1-git components.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/27fac4b8-d734-4516-bcfd-b7eacf99dc9f/1-git_components.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033033Z&X-Amz-Expires=86400&X-Amz-Signature=0d8ef80a9ddbd0372608ccc872486dc90ff4e2a7464d7387a233b970f4264dfd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%221-git%2520components.png%22&x-id=GetObject)
+![1-git_components.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/27fac4b8-d734-4516-bcfd-b7eacf99dc9f/1-git_components.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033033Z&X-Amz-Expires=86400&X-Amz-Signature=0d8ef80a9ddbd0372608ccc872486dc90ff4e2a7464d7387a233b970f4264dfd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%221-git%2520components.png%22&x-id=GetObject)
 
 Next, set VS Code as Git default editor (or default for the editor you use). 
 
-![2-git editor.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/303cd5fe-c2da-4747-8ee0-e6efad06ea99/2-git_editor.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033056Z&X-Amz-Expires=86400&X-Amz-Signature=a24600f301ad20e02cbd5a0c15d89715620db44508f3b63f030cdcce0482992a&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%222-git%2520editor.png%22&x-id=GetObject)
+![2-git_editor.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/303cd5fe-c2da-4747-8ee0-e6efad06ea99/2-git_editor.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033056Z&X-Amz-Expires=86400&X-Amz-Signature=a24600f301ad20e02cbd5a0c15d89715620db44508f3b63f030cdcce0482992a&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%222-git%2520editor.png%22&x-id=GetObject)
 
 For every other step, we recommended keeping to the default choice.
 
@@ -21,7 +21,7 @@ For every other step, we recommended keeping to the default choice.
 
 We recommend you install the latest `nvm-setup.zip` of [**nvm-windows**](https://github.com/coreybutler/nvm-windows/releases) to manage multiple version installations of Node.js. When the installation of nvm is complete, run Git Bash as administrator to install Node with npm. 
 
-![3- git run as admin.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/21bf6be8-8c37-4469-9ef0-35645e622ac2/3-_git_run_as_admin.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033111Z&X-Amz-Expires=86400&X-Amz-Signature=f78d5523dc342cba09e611b6a10dce417f04879e6f5fd932b6ca647b9972f54e&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%223-%2520git%2520run%2520as%2520admin.png%22&x-id=GetObject)
+![3-git_run_as_admin.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/21bf6be8-8c37-4469-9ef0-35645e622ac2/3-_git_run_as_admin.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033111Z&X-Amz-Expires=86400&X-Amz-Signature=f78d5523dc342cba09e611b6a10dce417f04879e6f5fd932b6ca647b9972f54e&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%223-%2520git%2520run%2520as%2520admin.png%22&x-id=GetObject)
 
 Redwood uses the LTS version of Node. To install, run the following commands inside the terminal: 
 
@@ -41,7 +41,7 @@ Now you have both Node and npm installed! Redwood also uses yarn, which you can 
 
 *Example of Node.js, npm, and Yarn installation steps*
 
-![4.1-install yarn.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/c719a400-562f-452f-90d4-27d0aecbcbf8/4.1-install_yarn.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033123Z&X-Amz-Expires=86400&X-Amz-Signature=ac97a085abb0fc8cad7cdbbe36e0404dcf73b71d23c52fa126686964843c4bbd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%224.1-install%2520yarn.png%22&x-id=GetObject)
+![4-install_yarn.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/c719a400-562f-452f-90d4-27d0aecbcbf8/4.1-install_yarn.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033123Z&X-Amz-Expires=86400&X-Amz-Signature=ac97a085abb0fc8cad7cdbbe36e0404dcf73b71d23c52fa126686964843c4bbd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%224.1-install%2520yarn.png%22&x-id=GetObject)
 
 ## Congrats!
 

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -9,11 +9,11 @@ This guide provides a simple setup to start developing a RedwoodJS project on Wi
 Download the latest release of [**Git for Windows**](https://git-scm.com/download/win) and install it. 
 When installing Git, you can add the icon on the Desktop and add Git Bash profile to Windows Terminal if you use it, but it is optional. 
 
-![1-git_components.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/27fac4b8-d734-4516-bcfd-b7eacf99dc9f/1-git_components.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033033Z&X-Amz-Expires=86400&X-Amz-Signature=0d8ef80a9ddbd0372608ccc872486dc90ff4e2a7464d7387a233b970f4264dfd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%221-git%2520components.png%22&x-id=GetObject)
+![1-git_components.png](https://user-images.githubusercontent.com/18013532/146685298-b12ed1a5-fe99-4286-ab12-69cf0a7be139.png)
 
 Next, set VS Code as Git default editor (or pick any other editor you're comfortable with). 
 
-![2-git_editor.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/303cd5fe-c2da-4747-8ee0-e6efad06ea99/2-git_editor.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033056Z&X-Amz-Expires=86400&X-Amz-Signature=a24600f301ad20e02cbd5a0c15d89715620db44508f3b63f030cdcce0482992a&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%222-git%2520editor.png%22&x-id=GetObject)
+![2-git_editor.png](https://user-images.githubusercontent.com/18013532/146685299-0e067554-a5a8-46b9-91ac-ffcd6f738b80.png)
 
 For all other steps, we recommended keeping to the default choices.
 
@@ -21,7 +21,7 @@ For all other steps, we recommended keeping to the default choices.
 
 We recommend you install the latest `nvm-setup.zip` of [**nvm-windows**](https://github.com/coreybutler/nvm-windows/releases) to manage multiple version installations of Node.js. When the installation of nvm is complete, run Git Bash as administrator to install Node with npm. 
 
-![3-git_run_as_admin.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/21bf6be8-8c37-4469-9ef0-35645e622ac2/3-_git_run_as_admin.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033111Z&X-Amz-Expires=86400&X-Amz-Signature=f78d5523dc342cba09e611b6a10dce417f04879e6f5fd932b6ca647b9972f54e&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%223-%2520git%2520run%2520as%2520admin.png%22&x-id=GetObject)
+![3-git_run_as_admin.png](https://user-images.githubusercontent.com/18013532/146685300-1762a00a-26cb-4f8b-b480-c6aba4e26b89.png)
 
 Redwood uses the LTS version of Node. To install, run the following commands inside the terminal: 
 
@@ -41,7 +41,7 @@ Now you have both Node and npm installed! Redwood also uses yarn, which you can 
 
 *Example of Node.js, npm, and Yarn installation steps*
 
-![4-install_yarn.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/c719a400-562f-452f-90d4-27d0aecbcbf8/4.1-install_yarn.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033123Z&X-Amz-Expires=86400&X-Amz-Signature=ac97a085abb0fc8cad7cdbbe36e0404dcf73b71d23c52fa126686964843c4bbd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%224.1-install%2520yarn.png%22&x-id=GetObject)
+![4-install_yarn.png](https://user-images.githubusercontent.com/18013532/146685297-b361ebea-7229-4d8c-bc90-472773d06816.png)
 
 ## Congrats!
 

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -1,6 +1,6 @@
 # Windows Development Setup
 
-This guide provides a simple setup to start developing a RedwoodJS project on Windows. Many setup options exist, but this aims to make getting started as easy as possible. This is the recommended setup unless you have experience with other shell like PowerShell. 
+This guide provides a simple setup to start developing a RedwoodJS project on Windows. Many setup options exist, but this aims to make getting started as easy as possible. This is the recommended setup unless you have experience with some other shell, like PowerShell. 
 
 > If you're interested in using the Windows Subsystem for Linux instead, there is a [community guide for that](https://community.redwoodjs.com/t/windows-subsystem-for-linux-setup/2439).
 

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -11,7 +11,7 @@ When installing Git, you can add the icon on the Desktop and add Git Bash profil
 
 ![1-git_components.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/27fac4b8-d734-4516-bcfd-b7eacf99dc9f/1-git_components.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033033Z&X-Amz-Expires=86400&X-Amz-Signature=0d8ef80a9ddbd0372608ccc872486dc90ff4e2a7464d7387a233b970f4264dfd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%221-git%2520components.png%22&x-id=GetObject)
 
-Next, set VS Code as Git default editor (or default for the editor you use). 
+Next, set VS Code as Git default editor (or pick any other editor you're comfortable with). 
 
 ![2-git_editor.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/303cd5fe-c2da-4747-8ee0-e6efad06ea99/2-git_editor.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033056Z&X-Amz-Expires=86400&X-Amz-Signature=a24600f301ad20e02cbd5a0c15d89715620db44508f3b63f030cdcce0482992a&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%222-git%2520editor.png%22&x-id=GetObject)
 

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -9,11 +9,11 @@ This guide provides a simple setup to start developing a RedwoodJS project on Wi
 Download the last release of [**Git for Windows**](https://git-scm.com/download/win) and install it. 
 When installing Git, you can add the icon on the Desktop and add Git Bash profile to Windows Terminal if you use it, but it is optional. 
 
-![1-git components.png](Windows%20setup%20for%20Redwood%20aa3e6e732a8440708763a609984ce495/1-git_components.png)
+![1-git components.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/27fac4b8-d734-4516-bcfd-b7eacf99dc9f/1-git_components.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033033Z&X-Amz-Expires=86400&X-Amz-Signature=0d8ef80a9ddbd0372608ccc872486dc90ff4e2a7464d7387a233b970f4264dfd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%221-git%2520components.png%22&x-id=GetObject)
 
 Next, set VS Code as Git default editor (or default for the editor you use). 
 
-![2-git editor.png](Windows%20setup%20for%20Redwood%20aa3e6e732a8440708763a609984ce495/2-git_editor.png)
+![2-git editor.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/303cd5fe-c2da-4747-8ee0-e6efad06ea99/2-git_editor.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033056Z&X-Amz-Expires=86400&X-Amz-Signature=a24600f301ad20e02cbd5a0c15d89715620db44508f3b63f030cdcce0482992a&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%222-git%2520editor.png%22&x-id=GetObject)
 
 For every other step, we recommended keeping to the default choice.
 
@@ -21,7 +21,7 @@ For every other step, we recommended keeping to the default choice.
 
 We recommend you install the latest `nvm-setup.zip` of [**nvm-windows**](https://github.com/coreybutler/nvm-windows/releases) to manage multiple version installations of Node.js. When the installation of nvm is complete, run Git Bash as administrator to install Node with npm. 
 
-![3- git run as admin.png](Windows%20setup%20for%20Redwood%20aa3e6e732a8440708763a609984ce495/3-_git_run_as_admin.png)
+![3- git run as admin.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/21bf6be8-8c37-4469-9ef0-35645e622ac2/3-_git_run_as_admin.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033111Z&X-Amz-Expires=86400&X-Amz-Signature=f78d5523dc342cba09e611b6a10dce417f04879e6f5fd932b6ca647b9972f54e&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%223-%2520git%2520run%2520as%2520admin.png%22&x-id=GetObject)
 
 Redwood uses the LTS version of Node. To install, run the following commands inside the terminal: 
 
@@ -41,7 +41,7 @@ Now you have both Node and npm installed! Redwood also uses yarn, which you can 
 
 *Example of Node.js, npm, and Yarn installation steps*
 
-![4.1-install yarn.png](Windows%20setup%20for%20Redwood%20aa3e6e732a8440708763a609984ce495/4.1-install_yarn.png)
+![4.1-install yarn.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/c719a400-562f-452f-90d4-27d0aecbcbf8/4.1-install_yarn.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033123Z&X-Amz-Expires=86400&X-Amz-Signature=ac97a085abb0fc8cad7cdbbe36e0404dcf73b71d23c52fa126686964843c4bbd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%224.1-install%2520yarn.png%22&x-id=GetObject)
 
 ## Congrats!
 

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -15,7 +15,7 @@ Next, set VS Code as Git default editor (or pick any other editor you're comfort
 
 ![2-git_editor.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/303cd5fe-c2da-4747-8ee0-e6efad06ea99/2-git_editor.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033056Z&X-Amz-Expires=86400&X-Amz-Signature=a24600f301ad20e02cbd5a0c15d89715620db44508f3b63f030cdcce0482992a&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%222-git%2520editor.png%22&x-id=GetObject)
 
-For every other step, we recommended keeping to the default choice.
+For all other steps, we recommended keeping to the default choices.
 
 ### Node.js environment (and npm)
 

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -4,7 +4,7 @@ This guide provides a simple setup to start developing a RedwoodJS project on Wi
 
 > If you're interested in using the Windows Subsystem for Linux instead, there is a [community guide for that](https://community.redwoodjs.com/t/windows-subsystem-for-linux-setup/2439).
 
-### **Git Bash**
+### Git Bash
 
 Download the last release of [**Git for Windows**](https://git-scm.com/download/win) and install it. 
 When installing Git, you can add the icon on the Desktop and add Git Bash profile to Windows Terminal if you use it, but it is optional. 
@@ -17,7 +17,7 @@ Next, set VS Code as Git default editor (or default for the editor you use).
 
 For every other step, we recommended keeping to the default choice.
 
-### **Node.js environment (and npm)**
+### Node.js environment (and npm)
 
 We recommend you install the latest `nvm-setup.zip` of [**nvm-windows**](https://github.com/coreybutler/nvm-windows/releases) to manage multiple version installations of Node.js. When the installation of nvm is complete, run Git Bash as administrator to install Node with npm. 
 
@@ -43,7 +43,7 @@ Now you have both Node and npm installed! Redwood also uses yarn, which you can 
 
 ![4.1-install yarn.png](Windows%20setup%20for%20Redwood%20aa3e6e732a8440708763a609984ce495/4.1-install_yarn.png)
 
-## **Congrats**!
+## Congrats!
 
 You now have everything ready to build your Redwood app. Just run:
 

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -6,7 +6,7 @@ This guide provides a simple setup to start developing a RedwoodJS project on Wi
 
 ### Git Bash
 
-Download the last release of [**Git for Windows**](https://git-scm.com/download/win) and install it. 
+Download the latest release of [**Git for Windows**](https://git-scm.com/download/win) and install it. 
 When installing Git, you can add the icon on the Desktop and add Git Bash profile to Windows Terminal if you use it, but it is optional. 
 
 ![1-git_components.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/27fac4b8-d734-4516-bcfd-b7eacf99dc9f/1-git_components.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211208%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211208T033033Z&X-Amz-Expires=86400&X-Amz-Signature=0d8ef80a9ddbd0372608ccc872486dc90ff4e2a7464d7387a233b970f4264dfd&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%221-git%2520components.png%22&x-id=GetObject)

--- a/cookbook/windows_setup.md
+++ b/cookbook/windows_setup.md
@@ -54,4 +54,4 @@ yarn create redwood-app ./myApp
 Next, you should start the amazing [**Redwood Tutorial**](https://learn.redwoodjs.com/docs/tutorial/installation-starting-development) to learn how to use the framework. 
 
 >⚠️ Heads Up  
-On Windows Git Bash, `cd dev` and `cd Dev` will select the same directory because Windows is case-insensitive. But make sure you type the original capitalization to avoid strange errors in your Redwood project.
+On Windows Git Bash, `cd myapp` and `cd myApp` will select the same directory because Windows is case-insensitive. But make sure you type the original capitalization to avoid strange errors in your Redwood project.

--- a/lib/build.js
+++ b/lib/build.js
@@ -192,6 +192,7 @@ const SECTIONS = [
         file: './cookbook/Background_Worker.md',
         title: 'Creating a Background Worker with Exec and Faktory',
       },
+      { pageBreakAtHeadingDepth: [1], file: './cookbook/windows_setup.md' },
     ],
   },
   {


### PR DESCRIPTION
This guide provides a simple setup to start developing a RedwoodJS project on Windows.

> - [x] add it as a Cookbook to the website docs
> - [x] link to it from the Tutorial prerequisites
> - [ ] also link to it from the Forum post (once it’s live)
> 
> _to-do from @thedavidprice_
