### PR TITLE
docs: Fix GraphQL Context import

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -230,7 +230,7 @@ Of the four, you'll see `args` and `root` being used a lot.
 
 ### Context
 
-In Redwood, the `context` object that's passed to resolvers is actually available to all your Services, whether or not they're serving as resolvers. Just import it from `@redwoodjs/api`:
+In Redwood, the `context` object that's passed to resolvers is actually available to all your Services, whether or not they're serving as resolvers. Just import it from `@redwoodjs/graphql-server`:
 
 ```javascript
 import { context } from '@redwoodjs/graphql-server'
@@ -607,7 +607,7 @@ export const handler = createGraphQLHandler({
 > **Relevant anatomy of an operation**
 >
 > In the example below, `"FilteredQuery"` is the operation's name.
-> That's what you'd  pass to `excludeOperations` if you wanted it filtered out.
+> That's what you'd pass to `excludeOperations` if you wanted it filtered out.
 >
 > ```js
 > export const filteredQuery = `


### PR DESCRIPTION
Says:

<img width="733" alt="image" src="https://user-images.githubusercontent.com/1051633/147513760-b54aa628-c901-45a3-b347-22db1c77ff99.png">


But should say:

```
Just import it from `@redwoodjs/graphql-server`:
```