### PR TITLE
Fix: Docs for mocking graphql error

### DIFF
--- a/docs/mockGraphQLRequests.md
+++ b/docs/mockGraphQLRequests.md
@@ -71,11 +71,11 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 <br/>
 
-- `ctx.errors(e: GraphQLError)`: return an error object in the response:
+- `ctx.errors(e: GraphQLError[])`: return an error object in the response:
 
 ```js{2}
 mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
-  ctx.errors({ message: 'Uh, oh!' })
+  ctx.errors([{ message: 'Uh, oh!' }])
 })
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -537,7 +537,7 @@ Along with `variables` there is a second argument: an object which you can destr
 
 ```javascript
 mockGraphQLQuery('getArticle', (variables, { ctx }) => {
-  ctx.errors({ message: 'Error' })
+  ctx.errors([{ message: 'Error' }])
 })
 ```
 
@@ -564,7 +564,7 @@ const Article = ({ id }) => {
 
 it('renders an error message', async () => {
   mockGraphQLQuery('getArticle', (variables, { ctx }) => {
-    ctx.errors({ message: 'Error' })
+    ctx.errors([{ message: 'Error' }])
   })
 
   render(<Article id={1} />)


### PR DESCRIPTION
IIRC since helix change, we now have an array of errors instead of a single object. @dthyresson Is that right? Would it be okay for you to review this one?