### PR TITLE
Add contributing content and update Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,27 @@
 # Roadmap
 
-_Last updated 29 September 2021_
+_Last updated February 1, 2022_
 
-RedwoodJS is very close to a stable version 1.0. In the last two years, the project has matured significantly and is already used in production by a number of startups. We intend to have a 1.0 release candidate before the end of 2021 and to release a truly production-ready 1.0 in early 2022. If you want to follow along with development, we are updating the ["Current Release Sprint"](https://github.com/redwoodjs/redwood/projects) GitHub project board several times a week. Once the "On Deck" and "In Progress" columns are complete, we'll be publishing the `v1.0.0-rc`.
+**RedwoodJS is very close to a stable version 1.0**. Over the last two years, the project has matured significantly and is already used in production by a number of startups. We have [released a 1.0 release candidate](https://community.redwoodjs.com/t/what-the-1-0-release-candidate-phase-means-and-when-1-0-will-drop/2604) and plan to release a truly production-ready 1.0 in the first half of 2022. Get excited 🚀
+
+> **What a v1 release candidate means:**
+> 1. all core features are complete and 
+> 2. we are done making breaking changes
+>
+> During the release candidate cycle, we are completing all remaining tasks necessary to publish the 1.0.0 GA.
+
+If you want to follow along with development, we are updating the ["Release"](https://github.com/redwoodjs/redwood/projects) GitHub project board continuously.
+
+## Contributors Wanted
+More importantly, *we need community help to reach 1.0.0*. There’s a Triage project board, including an important tab view of Issues that are priorities but need community help.
+- 👉 **Start here**: [v1 Help Wanted tab on the Triage Project Board](https://github.com/orgs/redwoodjs/projects/4) (sorted by difficulty)
+
+There are several contributing docs and references, each covering specific topics. Between the guides and the helpful community [Forums](https://community.redwoodjs.com) and [Discord](https://discord.gg/redwoodjs), you'll be up and running in no time:
+ - 👉 **Then go here**: [Contributing: Overview and Orientation](https://redwoodjs.com/docs/contributing-overview.html)
+
+## v1 Priorities
+> **Heads Up: Outdated Content**  
+> The following sections have not been updated since the v1.0.0-rc was released in December 2021.
 
 At this stage of development, when it's so important to keep the finish line in mind, a high-level overview is invaluable. Hence, this roadmap, and these color-coded labels:
 
@@ -25,19 +44,15 @@ Accessibility is a first-class concern. We want you to be able to build accessib
 
 A common theme leading up to `v1.0` will be that we want to make sure what we have actually works, so if you're savvy with a screen reader, testing the route announcer on multiple screen readers on multiple browsers would be invaluable feedback! 
 
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
-
 ## Auth
 
 <span id="status-4" class="font-mono">Polishing</span>
 
 Authentication and authorization are questions Redwood has had answers to since `v0.7`. Redwood has easy-to-install, sophisticated auth for a variety of providers. There's even role-based access controls (RBACs)! Authentication and authorization are integrated across the whole stack, and when `v1.0` rolls around, your Services will be secure by default. For more, see [Security](https://redwoodjs.com/docs/security).
 
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
-
 ## Core
 
-<span id="status-3" class="font-mono">Making it happen</span>
+<span id="status-4" class="font-mono">Making it happen</span>
 
 Redwood depends on a few libraries&mdash;namely Prisma&mdash;for some of its core functionality. For us to be `v1.0`, they have to be too. With Prisma recently carrying Migrate and Studio to general availability (GA) to complete the ORM, it's safe to say that they're ready to go. As we transition to Envelop and polish Cells, GraphQL is one of the other core aspects of Redwood that's getting a lot of attention.
 
@@ -48,8 +63,6 @@ Redwood depends on a few libraries&mdash;namely Prisma&mdash;for some of its cor
 <span id="status-4" class="font-mono">Polishing</span>
 
 We want to be able to deploy everywhere and anywhere: serverless, serverful, to the edge—to the world! Much like auth, we've already got a great lineup: Netlify (done), Vercel (done), Render (done), AWS (done), and Google Cloud Run (in the works). We'll always be looking to add more and to support custom deployment strategies.
-
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
 
 ## Docs
 
@@ -67,25 +80,19 @@ One thing we plan on doing before `v1.0` is moving over to Docusarus to accommod
 
 Generators are part of what makes Redwood a joy. We've made generators more configurable, so you can do things like opt in and out of generating stories and test files, and generate files in TypeScript rather than JavaScript. Look out for another long awaited configuration option: the ability to specify the path—where things get generated.
 
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
-
 ## Logging
 
 <span id="status-4" class="font-mono">Polishing</span>
 
 Logging has wiped out almost all of the old-growth Redwoods in California. But that doesn't mean we're not fans of logging here at RedwoodJS. As long as the logging helps you figure out what your app is doing! A production Redwood app will need great logging, so we intend to make it easy to get hooked up.
 
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
-
 ## Performance
 
-<span id="status-2" class="font-mono">There's a plan</span>
+<span id="status-3" class="font-mono">There's a plan</span>
 
 Can you have great developer ergonomics **and** performance? We intend to find out.
 
 Bundle size will be important here, so a good place to start is by building with the stats flag (`yarn rw build --stats`). This will make Redwood bundle with the [Webpack Bundle Analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer).
-
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
 
 ## Prerender
 
@@ -107,15 +114,11 @@ We're not done by any means; there's a lot more features we'll add to Prerenderi
 
 We've written our own router for Redwood, and we need to make sure it's competitive with existing routers in the React ecosystem (e.g. React Router, Reach Router). We've taken a stance on desiring a flat routing scheme (vs a nested one) and this currently comes with some performance downsides, some of which we've addressed with Sets. There's a lot of little things for us to polish, so if you're looking to work on something with a smaller scope, the router's a great place to get started.
 
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
-
 ## Storybook
 
 <span id="status-4" class="font-mono">Polishing</span>
 
 Redwood's component-development workflow starts with Storybook. Being able to develop your components in isolation without ever starting the dev server is a real game-changer. Redwood even generates mock data for your Cells so you can iterate on all of your component states!
-
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
 
 ## Structure
 
@@ -123,24 +126,18 @@ Redwood's component-development workflow starts with Storybook. Being able to de
 
 Using Redwood's Structure package, we can use the same logic to power both an IDE (i.e. Jamstack IDE) and Redwood itself. Redwood Structure's most common use-case is getting the diagnostics of a complete Redwood project, but being able to programmatically talk about a Redwood project like an AST moves many other amazing things we can't anticipate into the adjacent possible.
 
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
-
 ## Testing (App)
 
 <span id="status-4" class="font-mono">Polishing</span>
 
 Redwood makes testing a first-class concern, and maybe even makes it fun? We've integrated testing for both sides, and even wrote a [tome](https://redwoodjs.com/docs/testing) telling you how to use it, from the ground-up. We've got a template for Functions in the works, which would all but bring our unit tests to a close. One thing we'd really like to add as a stretch goal is a GitHub Action so you can have CI from the get go!
 
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)
-
 ## TypeScript
 
-<span id="status-3" class="font-mono">Making it happen</span>
+<span id="status-4" class="font-mono">Making it happen</span>
 
 The [TypeScript tracking issue](https://github.com/redwoodjs/redwood/issues/234) easily has the most reactions of any of our issues and PRs. Bit by bit we've made Redwood more and more TypeScript compliant. [@corbt](https://github.com/corbt) (Kyle Corbitt) even [graphed our progress](https://github.com/redwoodjs/redwood/issues/234#issuecomment-792390125)! 
 
 [Cells](https://github.com/redwoodjs/redwood/pull/2208) were one of the more-recent additions. And some of the things we've got coming, like [GraphQL Codegen](https://github.com/redwoodjs/redwood/pull/2485), are going to be icing on the cake.
 
 Although we want Redwood apps to default to TypeScript, you can still just stick to JS! It's totally up to you. All of our utilities, like generators, support both.
-
-[GitHub Project Board](https://github.com/redwoodjs/redwood/projects/20)

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS | The App Framework for Startups", "version": "v0.39.0" })
+@@layout("application", { "title": "RedwoodJS | The App Framework for Startups", "version": "v0.43.0" })
 @@contentFor("hero",
 <div class="bg-red-100">
   <div class="lg:flex lg:items-center max-w-screen-xl mx-auto px-8 py-12 md:py-20">

--- a/code/html/logos.html
+++ b/code/html/logos.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS | The App Framework for Startups", "version": "v0.39.0" })
+@@layout("application", { "title": "RedwoodJS | The App Framework for Startups", "version": "v0.43.0" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center pb-16">

--- a/code/html/roadmap.html
+++ b/code/html/roadmap.html
@@ -35,7 +35,7 @@
           
           <li class="my-1 py-1" style="margin-left: 0rem;">
             <a href="#core" data-turbolinks="false">
-              <span id="status-3">Core</span>
+              <span id="status-4">Core</span>
             </a>
           </li>
           
@@ -65,7 +65,7 @@
           
           <li class="my-1 py-1" style="margin-left: 0rem;">
             <a href="#performance" data-turbolinks="false">
-              <span id="status-2">Performance</span>
+              <span id="status-3">Performance</span>
             </a>
           </li>
           
@@ -101,7 +101,7 @@
           
           <li class="my-1 py-1" style="margin-left: 0rem;">
             <a href="#typescript" data-turbolinks="false">
-              <span id="status-3">TypeScript</span>
+              <span id="status-4">TypeScript</span>
             </a>
           </li>
           

--- a/code/html/roadmap.html
+++ b/code/html/roadmap.html
@@ -116,7 +116,7 @@
 <p><em>Last updated February 1, 2022</em></p>
 <p><strong>RedwoodJS is very close to a stable version 1.0</strong>. Over the last two years, the project has matured significantly and is already used in production by a number of startups. We have <a href="https://community.redwoodjs.com/t/what-the-1-0-release-candidate-phase-means-and-when-1-0-will-drop/2604">released a 1.0 release candidate</a> and plan to release a truly production-ready 1.0 in the first half of 2022. Get excited 🚀</p>
 <blockquote>
-<p>What a v1 release candidate means:</p>
+<p><strong>What a v1 release candidate means:</strong></p>
 <ol>
 <li>all core features are complete and</li>
 <li>we are done making breaking changes</li>
@@ -127,11 +127,11 @@
 <h2 id="contributors-wanted"><a class="markdownIt-Anchor" href="#contributors-wanted" data-turbolinks="false">#</a> Contributors Wanted</h2>
 <p>More importantly, <em>we need community help to reach 1.0.0</em>. There’s a Triage project board, including an important tab view of Issues that are priorities but need community help.</p>
 <ul>
-<li>👉 Start here: <a href="https://github.com/orgs/redwoodjs/projects/4">v1 Help Wanted tab on the Triage Project Board</a> (sorted by difficulty)</li>
+<li>👉 <strong>Start here</strong>: <a href="https://github.com/orgs/redwoodjs/projects/4">v1 Help Wanted tab on the Triage Project Board</a> (sorted by difficulty)</li>
 </ul>
 <p>There are several contributing docs and references, each covering specific topics. Between the guides and the helpful community <a href="https://community.redwoodjs.com">Forums</a> and <a href="https://discord.gg/redwoodjs">Discord</a>, you'll be up and running in no time:</p>
 <ul>
-<li><a href="https://redwoodjs.com/docs/contributing-overview.html">Contributing: Overview and Orientation</a></li>
+<li>👉 <strong>Then go here</strong>: <a href="https://redwoodjs.com/docs/contributing-overview.html">Contributing: Overview and Orientation</a></li>
 </ul>
 <h2 id="v1-priorities"><a class="markdownIt-Anchor" href="#v1-priorities" data-turbolinks="false">#</a> v1 Priorities</h2>
 <blockquote>
@@ -157,7 +157,7 @@ One of the hardest things in open source is saying no, but as we get closer to <
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Authentication and authorization are questions Redwood has had answers to since <code>v0.7</code>. Redwood has easy-to-install, sophisticated auth for a variety of providers. There's even role-based access controls (RBACs)! Authentication and authorization are integrated across the whole stack, and when <code>v1.0</code> rolls around, your Services will be secure by default. For more, see <a href="https://redwoodjs.com/docs/security">Security</a>.</p>
 <h2 id="core"><a class="markdownIt-Anchor" href="#core" data-turbolinks="false">#</a> Core</h2>
-<p><span id="status-3" class="font-mono">Making it happen</span></p>
+<p><span id="status-4" class="font-mono">Making it happen</span></p>
 <p>Redwood depends on a few libraries—namely Prisma—for some of its core functionality. For us to be <code>v1.0</code>, they have to be too. With Prisma recently carrying Migrate and Studio to general availability (GA) to complete the ORM, it's safe to say that they're ready to go. As we transition to Envelop and polish Cells, GraphQL is one of the other core aspects of Redwood that's getting a lot of attention.</p>
 <p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="deployment"><a class="markdownIt-Anchor" href="#deployment" data-turbolinks="false">#</a> Deployment</h2>
@@ -175,7 +175,7 @@ One of the hardest things in open source is saying no, but as we get closer to <
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Logging has wiped out almost all of the old-growth Redwoods in California. But that doesn't mean we're not fans of logging here at RedwoodJS. As long as the logging helps you figure out what your app is doing! A production Redwood app will need great logging, so we intend to make it easy to get hooked up.</p>
 <h2 id="performance"><a class="markdownIt-Anchor" href="#performance" data-turbolinks="false">#</a> Performance</h2>
-<p><span id="status-2" class="font-mono">There's a plan</span></p>
+<p><span id="status-3" class="font-mono">There's a plan</span></p>
 <p>Can you have great developer ergonomics <strong>and</strong> performance? We intend to find out.</p>
 <p>Bundle size will be important here, so a good place to start is by building with the stats flag (<code>yarn rw build --stats</code>). This will make Redwood bundle with the <a href="https://github.com/webpack-contrib/webpack-bundle-analyzer">Webpack Bundle Analyzer</a>.</p>
 <h2 id="prerender"><a class="markdownIt-Anchor" href="#prerender" data-turbolinks="false">#</a> Prerender</h2>
@@ -198,7 +198,7 @@ One of the hardest things in open source is saying no, but as we get closer to <
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Redwood makes testing a first-class concern, and maybe even makes it fun? We've integrated testing for both sides, and even wrote a <a href="https://redwoodjs.com/docs/testing">tome</a> telling you how to use it, from the ground-up. We've got a template for Functions in the works, which would all but bring our unit tests to a close. One thing we'd really like to add as a stretch goal is a GitHub Action so you can have CI from the get go!</p>
 <h2 id="typescript"><a class="markdownIt-Anchor" href="#typescript" data-turbolinks="false">#</a> TypeScript</h2>
-<p><span id="status-3" class="font-mono">Making it happen</span></p>
+<p><span id="status-4" class="font-mono">Making it happen</span></p>
 <p>The <a href="https://github.com/redwoodjs/redwood/issues/234">TypeScript tracking issue</a> easily has the most reactions of any of our issues and PRs. Bit by bit we've made Redwood more and more TypeScript compliant. <a href="https://github.com/corbt">@corbt</a> (Kyle Corbitt) even <a href="https://github.com/redwoodjs/redwood/issues/234#issuecomment-792390125">graphed our progress</a>!</p>
 <p><a href="https://github.com/redwoodjs/redwood/pull/2208">Cells</a> were one of the more-recent additions. And some of the things we've got coming, like <a href="https://github.com/redwoodjs/redwood/pull/2485">GraphQL Codegen</a>, are going to be icing on the cake.</p>
 <p>Although we want Redwood apps to default to TypeScript, you can still just stick to JS! It's totally up to you. All of our utilities, like generators, support both.</p>

--- a/code/html/roadmap.html
+++ b/code/html/roadmap.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "Roadmap : RedwoodJS Docs", "version": "v0.39.0" })
+@@layout("application", { "title": "Roadmap : RedwoodJS Docs", "version": "v0.43.0" })
 
 @@contentFor("aside",
   <aside class="hidden xl:block w-1/4 h-auto overflow-y-visible">
@@ -8,6 +8,18 @@
           <h4 class="text-xs uppercase text-gray-500">On this page</h4>
         
         <ul class="mt-4 pointer-events-auto">
+          
+          <li class="my-1 py-1" style="margin-left: 0rem;">
+            <a href="#contributors-wanted" data-turbolinks="false">
+              <span id="status-">Contributors Wanted</span>
+            </a>
+          </li>
+          
+          <li class="my-1 py-1" style="margin-left: 0rem;">
+            <a href="#v1-priorities" data-turbolinks="false">
+              <span id="status-">v1 Priorities</span>
+            </a>
+          </li>
           
           <li class="my-1 py-1" style="margin-left: 0rem;">
             <a href="#accessibility" data-turbolinks="false">
@@ -101,8 +113,31 @@
 
 <div class="markdown">
   <h1 id="roadmap"><a class="markdownIt-Anchor" href="#roadmap" data-turbolinks="false">#</a> Roadmap</h1>
-<p><em>Last updated 29 September 2021</em></p>
-<p>RedwoodJS is very close to a stable version 1.0. In the last two years, the project has matured significantly and is already used in production by a number of startups. We intend to have a 1.0 release candidate before the end of 2021 and to release a truly production-ready 1.0 in early 2022. If you want to follow along with development, we are updating the <a href="https://github.com/redwoodjs/redwood/projects">&quot;Current Release Sprint&quot;</a> GitHub project board several times a week. Once the &quot;On Deck&quot; and &quot;In Progress&quot; columns are complete, we'll be publishing the <code>v1.0.0-rc</code>.</p>
+<p><em>Last updated February 1, 2022</em></p>
+<p><strong>RedwoodJS is very close to a stable version 1.0</strong>. Over the last two years, the project has matured significantly and is already used in production by a number of startups. We have <a href="https://community.redwoodjs.com/t/what-the-1-0-release-candidate-phase-means-and-when-1-0-will-drop/2604">released a 1.0 release candidate</a> and plan to release a truly production-ready 1.0 in the first half of 2022. Get excited 🚀</p>
+<blockquote>
+<p>What a v1 release candidate means:</p>
+<ol>
+<li>all core features are complete and</li>
+<li>we are done making breaking changes</li>
+</ol>
+<p>During the release candidate cycle, we are completing all remaining tasks necessary to publish the 1.0.0 GA.</p>
+</blockquote>
+<p>If you want to follow along with development, we are updating the <a href="https://github.com/redwoodjs/redwood/projects">&quot;Release&quot;</a> GitHub project board continuously.</p>
+<h2 id="contributors-wanted"><a class="markdownIt-Anchor" href="#contributors-wanted" data-turbolinks="false">#</a> Contributors Wanted</h2>
+<p>More importantly, <em>we need community help to reach 1.0.0</em>. There’s a Triage project board, including an important tab view of Issues that are priorities but need community help.</p>
+<ul>
+<li>👉 Start here: <a href="https://github.com/orgs/redwoodjs/projects/4">v1 Help Wanted tab on the Triage Project Board</a> (sorted by difficulty)</li>
+</ul>
+<p>There are several contributing docs and references, each covering specific topics. Between the guides and the helpful community <a href="https://community.redwoodjs.com">Forums</a> and <a href="https://discord.gg/redwoodjs">Discord</a>, you'll be up and running in no time:</p>
+<ul>
+<li><a href="https://redwoodjs.com/docs/contributing-overview.html">Contributing: Overview and Orientation</a></li>
+</ul>
+<h2 id="v1-priorities"><a class="markdownIt-Anchor" href="#v1-priorities" data-turbolinks="false">#</a> v1 Priorities</h2>
+<blockquote>
+<p><strong>Heads Up: Outdated Content</strong><br>
+The following sections have not been updated since the v1.0.0-rc was released in December 2021.</p>
+</blockquote>
 <p>At this stage of development, when it's so important to keep the finish line in mind, a high-level overview is invaluable. Hence, this roadmap, and these color-coded labels:</p>
 <ul>
 <li><span id="status-0" class="font-mono">Didn't start</span></li>
@@ -118,11 +153,9 @@ One of the hardest things in open source is saying no, but as we get closer to <
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Accessibility is a first-class concern. We want you to be able to build accessible websites without having to jump through hoops. While accessibility is a broad topic that we plan to keep iterating on, <code>v1.0</code> will bring you a solid foundation, addressing key concerns, like route announcements and scroll. And the best part is: it's all baked-in.</p>
 <p>A common theme leading up to <code>v1.0</code> will be that we want to make sure what we have actually works, so if you're savvy with a screen reader, testing the route announcer on multiple screen readers on multiple browsers would be invaluable feedback!</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="auth"><a class="markdownIt-Anchor" href="#auth" data-turbolinks="false">#</a> Auth</h2>
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Authentication and authorization are questions Redwood has had answers to since <code>v0.7</code>. Redwood has easy-to-install, sophisticated auth for a variety of providers. There's even role-based access controls (RBACs)! Authentication and authorization are integrated across the whole stack, and when <code>v1.0</code> rolls around, your Services will be secure by default. For more, see <a href="https://redwoodjs.com/docs/security">Security</a>.</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="core"><a class="markdownIt-Anchor" href="#core" data-turbolinks="false">#</a> Core</h2>
 <p><span id="status-3" class="font-mono">Making it happen</span></p>
 <p>Redwood depends on a few libraries—namely Prisma—for some of its core functionality. For us to be <code>v1.0</code>, they have to be too. With Prisma recently carrying Migrate and Studio to general availability (GA) to complete the ORM, it's safe to say that they're ready to go. As we transition to Envelop and polish Cells, GraphQL is one of the other core aspects of Redwood that's getting a lot of attention.</p>
@@ -130,7 +163,6 @@ One of the hardest things in open source is saying no, but as we get closer to <
 <h2 id="deployment"><a class="markdownIt-Anchor" href="#deployment" data-turbolinks="false">#</a> Deployment</h2>
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>We want to be able to deploy everywhere and anywhere: serverless, serverful, to the edge—to the world! Much like auth, we've already got a great lineup: Netlify (done), Vercel (done), Render (done), AWS (done), and Google Cloud Run (in the works). We'll always be looking to add more and to support custom deployment strategies.</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="docs"><a class="markdownIt-Anchor" href="#docs" data-turbolinks="false">#</a> Docs</h2>
 <p><span id="status-3" class="font-mono">Making it happen</span></p>
 <p>A major part of Redwood's initial success was it's tutorial. The practice of readable, enjoyable, and comprehensive documentation is something we plan to continue. Getting to <code>v1.0</code> doesn't mean sacrificing the quality of docs; on the contrary, the more the framework can do, the better the docs have to be.</p>
@@ -139,16 +171,13 @@ One of the hardest things in open source is saying no, but as we get closer to <
 <h2 id="generators"><a class="markdownIt-Anchor" href="#generators" data-turbolinks="false">#</a> Generators</h2>
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Generators are part of what makes Redwood a joy. We've made generators more configurable, so you can do things like opt in and out of generating stories and test files, and generate files in TypeScript rather than JavaScript. Look out for another long awaited configuration option: the ability to specify the path—where things get generated.</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="logging"><a class="markdownIt-Anchor" href="#logging" data-turbolinks="false">#</a> Logging</h2>
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Logging has wiped out almost all of the old-growth Redwoods in California. But that doesn't mean we're not fans of logging here at RedwoodJS. As long as the logging helps you figure out what your app is doing! A production Redwood app will need great logging, so we intend to make it easy to get hooked up.</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="performance"><a class="markdownIt-Anchor" href="#performance" data-turbolinks="false">#</a> Performance</h2>
 <p><span id="status-2" class="font-mono">There's a plan</span></p>
 <p>Can you have great developer ergonomics <strong>and</strong> performance? We intend to find out.</p>
 <p>Bundle size will be important here, so a good place to start is by building with the stats flag (<code>yarn rw build --stats</code>). This will make Redwood bundle with the <a href="https://github.com/webpack-contrib/webpack-bundle-analyzer">Webpack Bundle Analyzer</a>.</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="prerender"><a class="markdownIt-Anchor" href="#prerender" data-turbolinks="false">#</a> Prerender</h2>
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Along with TypeScript, Prerendering was one of our most-requested features. It's been available for some time now; all you have to do is add a single prop to one of your Routes:</p>
@@ -159,25 +188,20 @@ One of the hardest things in open source is saying no, but as we get closer to <
 <h2 id="router"><a class="markdownIt-Anchor" href="#router" data-turbolinks="false">#</a> Router</h2>
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>We've written our own router for Redwood, and we need to make sure it's competitive with existing routers in the React ecosystem (e.g. React Router, Reach Router). We've taken a stance on desiring a flat routing scheme (vs a nested one) and this currently comes with some performance downsides, some of which we've addressed with Sets. There's a lot of little things for us to polish, so if you're looking to work on something with a smaller scope, the router's a great place to get started.</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="storybook"><a class="markdownIt-Anchor" href="#storybook" data-turbolinks="false">#</a> Storybook</h2>
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Redwood's component-development workflow starts with Storybook. Being able to develop your components in isolation without ever starting the dev server is a real game-changer. Redwood even generates mock data for your Cells so you can iterate on all of your component states!</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="structure"><a class="markdownIt-Anchor" href="#structure" data-turbolinks="false">#</a> Structure</h2>
 <p><span id="status-3" class="font-mono">Making it happen</span></p>
 <p>Using Redwood's Structure package, we can use the same logic to power both an IDE (i.e. Jamstack IDE) and Redwood itself. Redwood Structure's most common use-case is getting the diagnostics of a complete Redwood project, but being able to programmatically talk about a Redwood project like an AST moves many other amazing things we can't anticipate into the adjacent possible.</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="testing-app"><a class="markdownIt-Anchor" href="#testing-app" data-turbolinks="false">#</a> Testing (App)</h2>
 <p><span id="status-4" class="font-mono">Polishing</span></p>
 <p>Redwood makes testing a first-class concern, and maybe even makes it fun? We've integrated testing for both sides, and even wrote a <a href="https://redwoodjs.com/docs/testing">tome</a> telling you how to use it, from the ground-up. We've got a template for Functions in the works, which would all but bring our unit tests to a close. One thing we'd really like to add as a stretch goal is a GitHub Action so you can have CI from the get go!</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 <h2 id="typescript"><a class="markdownIt-Anchor" href="#typescript" data-turbolinks="false">#</a> TypeScript</h2>
 <p><span id="status-3" class="font-mono">Making it happen</span></p>
 <p>The <a href="https://github.com/redwoodjs/redwood/issues/234">TypeScript tracking issue</a> easily has the most reactions of any of our issues and PRs. Bit by bit we've made Redwood more and more TypeScript compliant. <a href="https://github.com/corbt">@corbt</a> (Kyle Corbitt) even <a href="https://github.com/redwoodjs/redwood/issues/234#issuecomment-792390125">graphed our progress</a>!</p>
 <p><a href="https://github.com/redwoodjs/redwood/pull/2208">Cells</a> were one of the more-recent additions. And some of the things we've got coming, like <a href="https://github.com/redwoodjs/redwood/pull/2485">GraphQL Codegen</a>, are going to be icing on the cake.</p>
 <p>Although we want Redwood apps to default to TypeScript, you can still just stick to JS! It's totally up to you. All of our utilities, like generators, support both.</p>
-<p><a href="https://github.com/redwoodjs/redwood/projects/20">GitHub Project Board</a></p>
 
   
 </div>

--- a/code/html/security.html
+++ b/code/html/security.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS | The App Framework for Startups", "version": "v0.39.0" })
+@@layout("application", { "title": "RedwoodJS | The App Framework for Startups", "version": "v0.43.0" })
 
 <div class="xl:-mr-56">
   <header>

--- a/code/html/stickers-thanks.html
+++ b/code/html/stickers-thanks.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.39.0" })
+@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.43.0" })
 
 <style type="text/css">
   :root {

--- a/code/html/stickers.html
+++ b/code/html/stickers.html
@@ -1,4 +1,4 @@
-@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.39.0" })
+@@layout("application", { "title": "RedwoodJS - Get a sticker!", "version": "v0.43.0" })
 
 <div class="xl:-mr-56">
   <section class="max-w-4xl mx-auto text-center">

--- a/docs/contributing-walkthrough.md
+++ b/docs/contributing-walkthrough.md
@@ -1,0 +1,230 @@
+# Contributing: Step-by-Step Walkthrough (with Video)
+
+> ⚡️ **Quick Links**  
+> There are several contributing docs and references, each covering specific topics:
+> 1. 🧭 [Overview and Orientation](https://redwoodjs.com/docs/contributing-overview.html)
+> 2. 📓 [Reference: Contributing to the Framework Packages](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md)
+> 3. 🪜 **Step-by-step Walkthrough** (👈 you are here)
+> 4. 📈 [Current Project Status: v1 Release Board](https://github.com/orgs/redwoodjs/projects/6)
+> 5. 🤔 What should I work on?  
+>     - ["Help Wanted" v1 Triage Board](https://redwoodjs.com/good-first-issue)  
+>     - [Discovery Process and Open Issues](https://redwoodjs.com/docs/contributing#what-should-i-work-on)   
+
+
+## Video Recording of Complete Contributing Process
+The following recording is from a Contributing Workshop, following through the exact steps outlined below. The Workshop includes additional topics along with Q&A discussion.
+
+<iframe
+  class="w-full"
+  style="height: 24rem;"
+  src="https://www.youtube.com/embed/aZs_9g-5Ms8"
+  frameborder="0"
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0"
+  allowfullscreen
+></iframe>
+
+## Prologue: Getting Started with Redwood and GitHub (and git)
+These are the foundations for contributing, which you should be familiar with before starting the walkthrough.
+
+**The Redwood Tutorial**  
+The best (and most fun) way to learn Redwood and the underlying tools and technologies:
+- [Tutorial Part 1](https://redwoodjs.com/tutorial)
+- [Tutorial Part 2](https://redwoodjs.com/tutorial2/welcome-to-redwood-part-ii-redwood-s-revenge)
+
+**Docs and Cookbook**  
+- Start with the [Introduction](https://redwoodjs.com/docs/introduction) Doc
+- And browse through [Cookbook recipes](https://redwoodjs.com/docs/cookbook)
+
+### GitHub (and Git)
+Diving into Git and the GitHub workflow can feel intimidating if you haven’t experienced it before. The good news is there’s a lot of great material to help you learn and be committing in no time!
+
+- [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github) (overview of concepts and workflow)
+- [First Day on GitHub](https://lab.github.com/githubtraining/first-day-on-github) (including Git)
+- [First Week on GitHub](https://lab.github.com/githubtraining/first-week-on-github) (parts 3 and 4 might be helpful)
+
+## The Full Workflow: From Local Development to a New PR
+
+### Definitions
+#### Redwood “Project”
+We refer to the codebase of a Redwood application as a Project. This is what you install when you run `yarn create redwood-app <path-to-directory>`. It’s the thing you are building with Redwood. 
+
+Lastly, you’ll find the template used to create a new project (when you run create redwood-app) here in GitHub: [redwoodjs/redwood/packages/create-redwood-app/template/](https://github.com/redwoodjs/redwood/tree/main/packages/create-redwood-app/template)
+
+We refer to this as the **CRWA Template or Project Template**.
+
+#### Redwood “Framework”
+The Framework is the codebase containing all the packages (and other code) that is published on NPMjs.com as `@redwoodjs/<package-name>`. The Framework repository on GitHub is here: [https://github.com/redwoodjs/redwood](https://github.com/redwoodjs/redwood)
+
+### Development tools
+These are the tools used and recommended by the Core Team.
+
+**VS Code**  
+[Download VS Code](https://code.visualstudio.com/download)  
+This has quickly become the de facto editor for JavaScript and TypeScript. Additionally, we have added recommended VS Code Extensions to use when developing both the Framework and a Project. You’ll see a pop-up window asking you about installing the extensions when you open up the code.
+
+**GitHub Desktop**  
+[Download GitHub Desktop](https://desktop.github.com)  
+You’ll need to be comfortable using Git at the command line. But the thing ew like best about GitHub Desktop is how easy it makes workflow across GitHub <> GitHub Desktop <> VS Code. You don’t have to worry about syncing permissions or finding things. You can start from a repo on GitHub.com and use Desktop to do everything from “clone and open on your computer” to returning back to the site to “open a PR on GitHub”.
+
+**[Mac OS] iTerm and Oh-My-Zsh**  
+There’s nothing wrong with Terminal (on Mac) and bash. (If you’re on Windows, we highly recommend using Git for Windows and Git bash.) But we enjoy using iTerm ([download](https://iterm2.com)) and Zsh much more (use [Oh My Zsh](https://ohmyz.sh)). Heads up, you can get lost in the world of theming and adding plugins. We recommend keeping it simple for awhile before taking the customization deep dive 
+😉
+
+**[Windows] Git for Windows with Git Bash or WSL(2)**  
+Unfortunately, there are a lot of “gotchas” when it comes to working with Javascript-based frameworks on Windows. We do our best to point out (and resolve) issues, but our priority focus is on developing a Redwood app vs contributing to the Framework. (If you’re interested, there’s a lengthy Forum conversation about this with many suggestions.) 
+
+All that said, we highly recommend using one of the following setups to maximize your workflow:
+1. Use [Git for Windows and Git Bash](https://redwoodjs.com/cookbook/windows-development-setup.html#windows-development-setup) (included in installation)
+2. Use [WSL following this setup guide on the Forums](https://community.redwoodjs.com/t/windows-subsystem-for-linux-setup/2439)
+
+Lastly, the new GitPod integration is a great option and only getting better. You might just want to start using it from the beginning (see section below in “Local Development Setup”).
+
+**GitPod**  
+We recently added an integration with [GitPod](http://gitpod.io) that automatically creates a Framework dev workspace, complete with test project, in a browser-based VS Code environment. It’s pretty amazing and we highly recommend giving it a shot. (If you’re developing on Windows, it’s also an amazing option for you anytime you run into something that isn’t working correctly or supported.)
+
+But don’t skip out reading the following steps in “Local Development Setup” — GitPod uses the same workflow and tools to initialize. If you want to develop in GitPod, you’ll need to understand how it all works.
+
+But when you’re ready, learn how to use it in the section at the end [“GitPod: Browser-based Development”](TODO).
+
+### Local Development Setup
+#### Step 1: Redwood Framework
+1. **Fork the [Redwood Framework](https://github.com/redwoodjs/redwood)** into a personal repo
+2. Using GitHub Desktop, **open the Framework Codebase** in a VS Code workspace
+3. Commands to “**start fresh**” when working on the Framework
+    - `yarn install`: This installs the package dependencies in /node_modules using Yarn package manager. This command is the same as just typing `yarn`. Also, if you ever switch branches and want to make sure the install dependencies are correct, you can run `yarn install --force` (shorthand `yarn -f`).
+    - `git clean -fxd`: *You’ll only need to do this if you’ve already been developing and want to “start over” and reset your codebase*. This command will permanently delete everything that is .gitignored, e.g. /node_modules and /dist directories with package builds. When switching between branches, this command makes sure nothing is carried over that you don’t want. (Warning: it will delete .env files in a Redwood Project. To avoid this, you can use `git clean -fxd -e .env`.)
+4. **Create a new branch** from the `main` branch
+First make sure you’ve pulled all changes from the remote origin (GitHub repo) into your local branch. (If you just cloned from your fork, you should be up to date.) Then create a new branch. The nomenclature used by David Price is `<davids_initials>-description-with-hyphens`, e.g. `dsp-add-eslint-config-redwood-toml`. It's simple to use VS Code or GitHub Desktop to manage branches. You can also do this via the CLI git checkout command.
+
+#### Step 2: Test Project
+There are several options for creating a local Redwood Project to use during development. Anytime you are developing against a test project, there are some specific gotchas to keep in mind:
+- New projects always use the latest stable version of the Redwood packages, which will not be up to date with the latest Framework code in the `main` branch.
+- To use the packages corresponding with the latest code in the Framework `main` branch, you can use the canary version published to NPM. All you need to do to install the canary versions is run `yarn rw upgrade --tag canary` in your Project
+- Using a cloned project or repo? Just know there are likely breaking changes in `main` that haven’t been applied. You can examine merged PRs with the “breaking” label for more info.
+- Just because you are using canary doesn’t mean you are using your local Framework branch code! Make sure you run `yarn rwfw project:sync`. And anytime you switch branches or get out of sync, you might need to start over beginning with the `git clean -fxd` command
+
+With those details out of the way, now is the time to choose an option below that meets your needs based on functionality and codebase version.
+
+**Build a Functional Test Project [Recommended]**  
+1. 👉 **Use the build script to create a test project**: From the Framework root directory, run `yarn build:test-project <path/to/directory>`. This command installs a new project using the Template codebase from your current Framework branch, it then adds Tutorial features, and finally it initializes the DB (with seed data!). It should work 90% of the time and is the recommended starting place. We also use this out-of-the-box with GitPod.
+
+**Other Options to create a project**  
+
+2. **Install a fresh project using the local Framework template code:** Sometimes you need to create a project that uses the Template codebase in your local branch of the Framework, e.g. your changes include modifications to the CRWA Template and need to be tested. Running the command above is exactly the same as `yarn create redwood- app …`, only it runs the command from your local Framework package using the local Template codebase. Note: this is the same command used at the start of the `yarn build:test-project` command. 
+```
+yarn babel-node packages/create-redwood-app/src/create-redwood-app.js <path/to/project>
+```
+
+3. **Clone the Redwood Tutorial App repo:** This is the codebase to use when starting the Redwood Tutorial Part 2. It is updated to the latest version and has the Blog features. This is often something we use for local development. Note: be sure to upgrade to canary and look out for breaking changes coming with the next release.
+
+
+4. **Install a fresh project**: `yarn create redwood-app <path/to/project>` If you just need a fresh installation 1) using the latest version template codebase and 2) without any features, then just install a new Redwood project. Note: this can have the same issues regarding the need to upgrade to canary and addressing breaking changes (see Notes from items 2 and 3 above).
+
+> Note: All the options above currently set the language to JavaScript. If you would like to work with TypeScript, you can add the option `--typescript` to either of the commands that run the create-redwood-app installation. 
+
+#### Step 3: Link the local Framework with the local test Project  
+Once you work on the Framework code, you’ll most often want to run the code in a Redwood app for testing. However, the Redwood Project you created for testing is currently using the latest version (or canary) packages of Redwood published on NPMjs.com, e.g. [@redwoodjs/core](https://www.npmjs.com/package/@redwoodjs/core)
+
+So we’ll use the Redwood Framework (rwfw) command to connect our local Framework and test Projects, which allows the Project to run on the code for Packages we are currently developing.
+
+Run this command from the CLI in your test Project: 
+```
+RWFW_PATH=<framework directory> yarn rwfw project:sync
+```
+
+For Example:
+```
+cd redwood-project
+RWFW_PATH=~/redwood yarn rwfw project:sync
+```
+
+RWFW_PATH is the path to your local copy of the Redwood Framework. _Once provided to rwfw, it'll remember it and you shouldn't have to provide it again unless you move it._
+
+> **Heads up for Windows Devs**  
+> Depending on your dev setup, Windows might balk at you setting the env var RWFW_PATH at the beginning of the command like this. If so, try prepending with `cross-env`, e.g. `yarn cross-env RWFW_PATH=~/redwood yarn rwfw` ... Or you can add the env var and value directly to your shell before running the command.
+
+As project:sync starts up, it'll start logging to the console. In order, it:
+1. cleans and builds the framework
+2. copies the framework's dependencies to your project
+3. runs yarn install in your project
+4. copies over the framework's packages to your project
+5. waits for changes
+
+Step two is the only explicit change you'll see to your project. You'll see that a ton of packages have been added to your project's root package.json.
+
+All done? You’re ready to kill the link process with “ctrl + c”. You’ll need to confirm your root package.json no longer has the added dependencies. And, if you want to reset your test-proje, you should run `yarn install --force`.
+
+#### Step 4: Framework Package(s) Local Testing  
+Within your Framework directory, use the following tools and commands to test your code:
+1. **Build the packages**: `yarn build`
+    - to delete all previous build directories: yarn build:clean
+2. **Syntax and Formatting**: `yarn lint`
+    - to fix errors or warnings: `yarn lint:fix`
+3. **Run unit tests for each package**: `yarn test`
+4. **Run through the Cypress E2E integration tests**: `yarn e2e`
+5. **Check Yarn resolutions and package.json format**: `yarn check`
+
+All of these checks are included in Redwood’s GitHub PR Continuous Integration (CI) automation. However, it’s good practice to understand what they do by using them locally. The E2E tests aren’t something we use every time anymore (because it takes a while), but you should learn how to use it because it comes in handy when your code is failing tests on GitHub and you need to diagnose.
+
+> **Heads up for Windows Devs**  
+> The Cypress E2E does *not* work on Windows. Two options are available if needed:
+> 1. Use GitPod (see related section for info)
+> 2. When you create a PR, just ask for help from a maintainer
+
+#### Step 5: Open a PR 🚀
+You’ve made it to the fun part! It’s time to use the code you’re working on to create a new PR into the Redwood Framework `main` branch.
+
+We use GitHub Desktop to walk through the process of:
+- committing my changes to my development branch
+- Publishing (pushing) my branch and changes to my GitHub repo fork of the Redwood Framework
+- Opening a PR requesting to merge my forked-repo branch into the Redwood Framework `main` branch
+
+Refer to the section above “What makes for a good Pull Request?” for advice on opening your PR.
+
+**Note:** Make sure you check the box to “allow project maintainers to update the code” (I’m not sure about the specific description used). This helps a PR move forward more quickly as branches always need to be updated from `main` before we can merge.
+
+**When is my code “ready” to open a PR?**  
+Most of the action, communication, and decisions happen within a PR. A common mistake new contributors make is *waiting* until their code is “perfect” before opening a PR. Assuming your PR has some code changes, it’s great practice to open a Draft PR (setting during the PR creation), which you can use to start discussion and ask questions. PRs are closed all the time without being merged, often because they are replaced by another PR resulting from decisions and discussion. It’s part of the process. More importantly, it means collaboration is happening!
+
+What isn’t a fun experience is spending a whole bunch of time on code that ends up not being the correct direction or is unnecessary/redundant to something that already exists. This is a part of the learning process. But it’s another reason to open a draft PR sooner than later to get confirmation and questions out of the way before investing time into refining and details.
+
+When in doubt, just try first and ask for help and direction!
+
+### GitPod: Browser-based Development
+[GitPod](http://gitpod.io) has recently been integrated with Redwood to JustWork™ with any branch or PR. When a virtual GitPod workspace is initialized, it automatically:
+1. Checks-out the code from your branch or PR
+2. Run Yarn installation
+3. Creates the functional Test Project via `yarn build:test-project`
+4. Syncs the Framework code with the Test Project
+5. Starts the Test Project dev server
+6. 🤯
+
+> **Chrome works best**  
+> We’ve noticed some bugs using GitPod with either Brave or Safari. Currently we recommend sticking to Chrome (although it’s worth trying out Edge and Firefox).
+
+**Demo of GitPod**  
+David briefly walks-through an automatically prebuilt GitPod workspace here:
+- [GitPod + RedwoodJS 3-minute Walkthough](https://youtu.be/_kMuTW3x--s)
+
+Make sure you watch until the end where David shows how to set up your integration with GitHub and VS Code sync. 🤩
+
+**Start a GitPod Workspace**  
+There are two ways to get started with GitPod + Redwood.
+
+*Option 1: Open a PR*  
+Every PR will trigger a GitPod prebuild using the PR branch. Just look for GitPod in the list of checks at the bottom of the PR — click the “Details” link and away you’ll go!
+
+<img width="350" alt="PR Checks" src="https://user-images.githubusercontent.com/2951/151928088-58e26232-b752-4471-adf4-a2bc59b79ac8.png">
+
+*Option 2: Use the link from your project or branch*  
+You can initialize a workspace using this URL pattern:
+```
+https://gitpod.io/#<URL for branch or project>
+```
+For example, this link will start a workspace using the RedwoodJS main branch:
+- https://gitpod.io/#https://github.com/redwoodjs/redwood
+
+And this link will start a workspace for a PR #3434:
+- https://gitpod.io/#https://github.com/redwoodjs/redwood/pull/3434
+
+

--- a/docs/contributing-walkthrough.md
+++ b/docs/contributing-walkthrough.md
@@ -1,7 +1,9 @@
 # Contributing: Step-by-Step Walkthrough (with Video)
 
 > ⚡️ **Quick Links**  
+> 
 > There are several contributing docs and references, each covering specific topics:
+> 
 > 1. 🧭 [Overview and Orientation](https://redwoodjs.com/docs/contributing-overview.html)
 > 2. 📓 [Reference: Contributing to the Framework Packages](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md)
 > 3. 🪜 **Step-by-step Walkthrough** (👈 you are here)

--- a/docs/contributing-walkthrough.md
+++ b/docs/contributing-walkthrough.md
@@ -84,7 +84,7 @@ We recently added an integration with [GitPod](http://gitpod.io) that automatica
 
 But don’t skip out reading the following steps in “Local Development Setup” — GitPod uses the same workflow and tools to initialize. If you want to develop in GitPod, you’ll need to understand how it all works.
 
-But when you’re ready, learn how to use it in the section at the end [“GitPod: Browser-based Development”](TODO).
+But when you’re ready, learn how to use it in the section at the end [“GitPod: Browser-based Development”](https://redwooodjs.com/docs/contributing-walkthrough#gitpod-browser-based-development).
 
 ### Local Development Setup
 #### Step 1: Redwood Framework

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,15 +1,70 @@
-# Contributing
+# Contributing: Overview and Orientation
 
-Love Redwood and want to get involved? You’re in the right place and in good company! As of this writing, there are more than [170 contributors](https://github.com/redwoodjs/redwood/blob/main/README.md#contributors) who have helped make Redwood awesome by contributing code and documentation. This doesn't include all those who participate in the vibrant, helpful, and encouraging Forums and Discord, which are both great places to get started if you have any questions.
+Love Redwood and want to get involved? You’re in the right place and in good company! As of this writing, there are more than [250 contributors](https://github.com/redwoodjs/redwood/blob/main/README.md#contributors) who have helped make Redwood awesome by contributing code and documentation. This doesn't include all those who participate in the vibrant, helpful, and encouraging Forums and Discord, which are both great places to get started if you have any questions.
 
 There are several ways you can contribute to Redwood:
 
-- join the [community Forums](https://community.redwoodjs.com/) and [Discord server](https://discord.gg/jjSYEQd)
-- triage [issues on the repo](https://github.com/redwoodjs/redwood/issues)
-- write and edit [docs](#contributing-docs)
-- and of course, write code!
+- join the [community Forums](https://community.redwoodjs.com/) and [Discord server](https://discord.gg/jjSYEQd) — enourage and help others 🙌
+- [triage issues on the repo](https://github.com/redwoodjs/redwood/issues) and [review PRs](https://github.com/redwoodjs/redwood/pulls) 🩺
+- write and edit [docs](#contributing-docs) ✍️
+- and of course, write code! 👩‍💻
 
-> Before interacting with the Redwood community, please read and understand our [Code of Conduct](https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct).
+_Before interacting with the Redwood community, please read and understand our [Code of Conduct](https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct)._
+
+> ⚡️ **Quick Links**  
+> There are several contributing docs and references, each covering specific topics:
+> 1. 🧭 **Overview and Orientation** (👈 you are here)
+> 2. 📓 [Reference: Contributing to the Framework Packages](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md)
+> 3. 🪜 [Step-by-step Walkthrough](https://redwoodjs.com/docs/contributing-walkthrough) (including Video Recording)
+> 4. 📈 [Current Project Status: v1 Release Board](https://github.com/orgs/redwoodjs/projects/6)
+> 5. 🤔 What should I work on?  
+>     - ["Help Wanted" v1 Triage Board](https://redwoodjs.com/good-first-issue)  
+>     - [Discovery Process and Open Issues](https://redwoodjs.com/docs/contributing#what-should-i-work-on)   
+
+## The Characteristics of a Contributor
+More than committing code, contributing is about human collaboration and relationship. Our community mantra is **“By helping each other be successful with Redwood, we make the Redwood project successful.”** We have a specific vision for the effect this project and community will have on you — it should give you superpowers to build+create, progress in skills, and help advance your career.
+
+So who do you need to become to achieve this? Specifically, what characteristics, skills, and capabilities will you need to cultivate through practice? Here are our suggestions:
+- Empathy
+- Gratitude
+- Generosity
+
+All of these are applicable in relation to both others and yourself. The goal of putting them into practice is to create trust that will be a catalyst for risk-taking (another word to describe this process is “learning”!). These are the ingredients necessary for productive, positive collaboration.
+
+And you thought all this was just about opening a PR 🤣 Yes, it’s a super rewarding experience. But that’s just the beginning!
+
+## What should I work on?
+Even if you know the mechanics, it’s hard to get started without a starting place. Our best advice is this — dive into the Redwood Tutorial, read the docs, and build your own experiment with Redwood. Along the way, you’ll find typos, out-of-date (or missing) documentation, code that could work better, or even opportunities for improving and adding features. You’ll be engaging in the Forums and Chat and developing a feel for priorities and needs. This way, you’ll naturally follow your own interests and sooner than later intersect “things you’re interested in” + “ways to help improve Redwood”.
+
+There are other more direct ways to get started as well, which are outlined below.
+
+### Roadmap to Redwood v1: Project Boards and GitHub Issues
+Over the next few months, our focus is to achieve a v1.0.0 release of Redwood. You can read Tom’s important announcement about the v1 release candidate process [via this forum post](https://community.redwoodjs.com/t/what-the-1-0-release-candidate-phase-means-and-when-1-0-will-drop/2604). 
+
+> What a v1 release candidate means:
+> 1. all core features are complete and 
+> 2. we are done making breaking changes
+>
+> During the release candidate cycle, we are completing all remaining tasks necessary to publish v1.0.0 GA.
+
+The Redwood Core Team is working publicly — progress is updated daily on the [Release Project Board](https://github.com/orgs/redwoodjs/projects/6). There’s also a Triage Board, including an important tab view of Issues that are priorities but need community help. 
+- 👉 **Start here**: [v1 Help Wanted tab on the Triage Project Board](https://github.com/orgs/redwoodjs/projects/4) (sorted by difficulty)
+
+
+Eventually, all this leads you back to Redwood’s GitHub Issues page. Here you’ll find open items that need help, which are organized by labels. There are four labels helpful for contributing:
+1. [Good First Issue](https://github.com/redwoodjs/redwood/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22): these items are more likely to be an accessible entry point to the Framework. It’s less about skill level and more about focused scope.
+2. [Help Wanted](https://github.com/redwoodjs/redwood/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22): these items especially need contribution help from the community.
+3. [v1 Priority](https://github.com/redwoodjs/redwood/issues?q=is%3Aissue+is%3Aopen+label%3Av1%2Fpriority+): to reach Redwood v1.0.0, we need to close all Issues with this label.
+4. [Bugs 🐛](https://github.com/redwoodjs/redwood/issues?q=is%3Aissue+is%3Aopen+label%3Abug%2Fconfirmed): Last but not least, we always need help with bugs. Some are technically less challenging than others. Sometimes the best way you can help is to attempt to reproduce the bug and confirm whether or not it’s still an issue.  
+
+**The sweet spot is a “v1 Priority” Issue that’s either a “Good First Issue” or “Help Wanted”.** Yes, please!
+
+### Create a New Issue
+Anyone can create a new Issue. If you’re not sure that your feature or idea is something to work on, start the discussion with an Issue. Describe the idea and problem + solution as clearly as possible, including examples or pseudo code if applicable. It’s also very helpful to `@` mention a maintainer or Core Team member that shares the area of interest.
+
+Just know that there’s a lot of Issues that shuffle every day. If no one replies, it’s just because people are busy. Reach out in the Forums, Chat, or comment in the Issue. We intend to reply to every Issue that’s opened. If yours doesn’t have a reply, then give us a nudge!
+
+Lastly, it can often be helpful to start with brief discussion in the community Chat or Forums. Sometimes that’s the quickest way to get feedback and a sense of priority before opening an Issue.
 
 ## Contributing Code
 
@@ -21,6 +76,7 @@ For details on contributing to a specific package, see the package's README (lin
 
 What you want to do not on the roadmap? Well, still go for it! We love spikes and proof-of-concepts. And if you have a question, just ask!
 
+### RedwoodJS Framework Packages
 |Package|Description|
 |:-|:-|
 |[`@redwoodjs/api-server`](https://github.com/redwoodjs/redwood/blob/main/packages/api-server/README.md)|Run a Redwood app using Express server (alternative to serverless API)|
@@ -90,3 +146,25 @@ So, after you've finished writing, reread what you wrote with the intention of m
 These docs are in the Framework repo, redwoodjs/redwood, and explain how to contribute to Redwood packages. They're the docs linked to in the table above.
 
 In general, they should consist of more straightforward explanations, are allowed to be technically heavy, and should be written for a more experienced audience. But as a best practice for collaborative projects, they should still provide a Vision + Roadmap and identify the project-point person(s) (or lead(s)).
+
+## What makes for a good Pull Request?
+In general, we don’t have a formal structure for PRs. Our goal is to make it as efficient as possible for anyone to open a PR. But there are some good practices, which are flexible. Just keep in mind that after opening a PR there’s more to do before getting to the finish line:
+1. Reviews from other contributors and maintainers
+2. Update code and, after maintainer approval, merge-in changes to the `main` branch
+3. Once PR is merged, it will be released and added to the next version Release Notes with a link for anyone to look at the PR and understand it. 
+
+Some tips and advice:
+- **Connect the dots and leave a breadcrumb**: link to related Issues, Forum discussions, etc. Help others follow the trail leading up to this PR.
+- **A Helpful Description**: What does the code in the PR do and what problem does it solve? How can someone use the code? Code sample, Screenshot, Quick Video… Any or all of this is so so good.
+- **Draft or Work in Progress**: You don’t have to finish the code to open a PR. Once you have a start, open it up! Most often the best way to move an Issue forward is to see the code in action. Also, often this helps identify ways forward before you spend a lot of time polishing.
+- **Questions, Items for Discussion, Etc.**: Another reason to open a Draft PR is to ask questions and get direction via review.
+- **Loop in a Maintainer for Feedback and Review**: ping someone with an `@`. And nudge again in a few days if there’s no reply. We appreciate it and truly don’t want the PR to get lost in the shuffle!
+- **Next Steps**: Once the PR is merged, will there be a follow up step? If so, link to an Issue. How about Docs to-do or Docs to-merge?    
+
+The best thing you can do is look through existing PRs, which will give you a feel for how things work and what you think is helpful.
+
+### Example PR
+If you’re looking for an example of “what makes a good PR”, look no further than this one by Kim-Adeline:
+- [Convert component generator to TS #632](https://github.com/redwoodjs/redwood/pull/632)
+
+Not every PR needs this much information. But it’s definitely helpful when it does!

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,9 @@ There are several ways you can contribute to Redwood:
 _Before interacting with the Redwood community, please read and understand our [Code of Conduct](https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct)._
 
 > ⚡️ **Quick Links**  
+>
 > There are several contributing docs and references, each covering specific topics:
+>
 > 1. 🧭 **Overview and Orientation** (👈 you are here)
 > 2. 📓 [Reference: Contributing to the Framework Packages](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md)
 > 3. 🪜 [Step-by-step Walkthrough](https://redwoodjs.com/docs/contributing-walkthrough) (including Video Recording)
@@ -41,7 +43,8 @@ There are other more direct ways to get started as well, which are outlined belo
 ### Roadmap to Redwood v1: Project Boards and GitHub Issues
 Over the next few months, our focus is to achieve a v1.0.0 release of Redwood. You can read Tom’s important announcement about the v1 release candidate process [via this forum post](https://community.redwoodjs.com/t/what-the-1-0-release-candidate-phase-means-and-when-1-0-will-drop/2604). 
 
-> What a v1 release candidate means:
+> **What a v1 release candidate means:**
+>
 > 1. all core features are complete and 
 > 2. we are done making breaking changes
 >

--- a/lib/build.js
+++ b/lib/build.js
@@ -71,6 +71,12 @@ const SECTIONS = [
       {
         pageBreakAtHeadingDepth: [1],
         url: './docs/contributing.md',
+        title: 'Contributing: Overview',
+      },
+      {
+        pageBreakAtHeadingDepth: [1],
+        url: './docs/contributing-walkthrough.md',
+        title: 'Contributing: Walkthrough',
       },
       {
         pageBreakAtHeadingDepth: [1],

--- a/lib/roadmap.js
+++ b/lib/roadmap.js
@@ -12,18 +12,18 @@ const run = () => {
   const styles = {
     Accessibility: 4,
     Auth: 4,
-    Core: 3,
+    Core: 4,
     Deployment: 4,
     Docs: 3,
     Generators: 4,
     Logging: 4,
-    Performance: 2,
+    Performance: 3,
     Prerender: 4,
     Router: 4,
     Storybook: 4,
     Structure: 3,
     ['Testing (App)']: 4,
-    TypeScript: 3,
+    TypeScript: 4,
   }
   const [page] = createDocs(
     markdown, 


### PR DESCRIPTION
@jtoar 

This PR includes content I've been using for the Contributing Workshop and intending to add to the docs. As of this tweet today, my deadline is now tomorrow 😬

- Adds content to [docs/contributing](https://deploy-preview-958--redwoodjs.netlify.app/docs/contributing-overview)
- Add new doc [docs/contributing-walkthrough](https://deploy-preview-958--redwoodjs.netlify.app/docs/contributing-walkthrough)
- Updates [/roadmap](https://deploy-preview-958--redwoodjs.netlify.app/roadmap)

I'm going to hit "merge" tomorrow morning. Please take a look for anything glaringly broken. We can refine as needed in a follow-up PR.

_PR to merge in parallel https://github.com/redwoodjs/redwood/pull/4325)_