### PR TITLE
cli: Add docs for 'secret'

### DIFF
--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -393,6 +393,7 @@ Some generators require that their argument be a model in your `schema.prisma`. 
 | `page <name> [path]`   | Generate a page component                                                                             |
 | `scaffold <model>`     | Generate Pages, SDL, and Services files based on a given DB schema Model. Also accepts `<path/model>` |
 | `sdl <model>`          | Generate a GraphQL schema and service object                                                          |
+| `secret`               | Generate a secret key using a cryptographically-secure source of entropy                              |
 | `service <name>`       | Generate a service component                                                                          |
 | `types`                | Generate types and supplementary code                                                                 |
 | `script <name>`        | Generate a script that can use your services/libs to execute with `redwood exec script <name>`        |
@@ -1148,6 +1149,22 @@ export const User = {
 }
 ```
 
+### generate secret
+
+Generate a secret key using a cryptographically-secure source of entropy. Commonly used when setting up dbAuth.
+
+| Arguments & Options | Description                                        |
+| :------------------ | :------------------------------------------------- |
+| `--raw`             | Print just the key, without any informational text |
+
+**Usage**
+
+Using the `--raw` option you can easily append a secret key to your .env file, like so:
+
+```
+echo "SESSION_SECRET=$(yarn --silent rw g secret --raw)" >> .env
+```
+
 ### generate service
 
 Generate a service component.
@@ -1578,22 +1595,6 @@ yarn rw record init
 ## redwood-tools (alias rwt)
 
 Redwood's companion CLI development tool. You'll be using this if you're contributing to Redwood. See [Contributing](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#cli-reference-redwood-tools) in the Redwood repo.
-
-## secret
-
-Generate a secret key using a cryptographically-secure source of entropy. Commonly used when setting up dbAuth.
-
-| Arguments & Options | Description                                        |
-| :------------------ | :------------------------------------------------- |
-| `--raw`             | Print just the key, without any informational text |
-
-### usage
-
-Using the `--raw` option you can easily append a secret key to your .env file, like so:
-
-```
-echo "SESSION_SECRET=$(yarn --silent rw g secret --raw)" >> .env
-```
 
 ## setup
 

--- a/docs/cliCommands.md
+++ b/docs/cliCommands.md
@@ -1579,6 +1579,22 @@ yarn rw record init
 
 Redwood's companion CLI development tool. You'll be using this if you're contributing to Redwood. See [Contributing](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#cli-reference-redwood-tools) in the Redwood repo.
 
+## secret
+
+Generate a secret key using a cryptographically-secure source of entropy. Commonly used when setting up dbAuth.
+
+| Arguments & Options | Description                                        |
+| :------------------ | :------------------------------------------------- |
+| `--raw`             | Print just the key, without any informational text |
+
+### usage
+
+Using the `--raw` option you can easily append a secret key to your .env file, like so:
+
+```
+echo "SESSION_SECRET=$(yarn --silent rw g secret --raw)" >> .env
+```
+
 ## setup
 
 Initialize configuration and integrate third-party libraries effortlessly.


### PR DESCRIPTION
We were missing docs for the `secret` cli command. So I went ahead and added that, together with documenting the "append SESSION_SECRET to your .env" use-case.

Related PR: https://github.com/redwoodjs/redwood/pull/4523