### PR TITLE
Fix typo in server config example

### DIFF
--- a/docs/appConfiguration.md
+++ b/docs/appConfiguration.md
@@ -179,7 +179,7 @@ Given an environment variable `DEPLOY_ENVIRONMENT` that declares `development`, 
 ```
 [api]
   port = 8911
-  serverConfig = = "./api/${DEPLOY_ENVIRONMENT}-server.config.js"
+  serverConfig = "./api/${DEPLOY_ENVIRONMENT}-server.config.js"
 ```
 
 ## [browser]


### PR DESCRIPTION
Typo to remove double equal in server.config.js example. We need only one. Easy to copy-paste. :D