### PR TITLE
Escape '|' character to fix formatting on markdown table

### DIFF
--- a/docs/cells.md
+++ b/docs/cells.md
@@ -53,16 +53,16 @@ Off the bat, this file exports five constants: `QUERY`, `Loading` , `Empty` , `F
 
 With Cells, you have a total of seven exports to work with:
 
-| Name          | Type              | Description                                                  |
-| :------------ | :---------------- | :----------------------------------------------------------- |
-| `QUERY`       | `string|function` | The query to execute                                         |
-| `beforeQuery` | `function`        | Lifecycle hook; prepares variables and options for the query |
-| `isEmpty`     | `function`        | Lifecycle hook; decides if Cell should render Empty          |
-| `afterQuery`  | `function`        | Lifecycle hook; sanitizes data returned from the query       |
-| `Loading`     | `component`       | If the request is in flight, render this component           |
-| `Empty`       | `component`       | If there's no data (`null` or `[]`), render this component   |
-| `Failure`     | `component`       | If something went wrong, render this component               |
-| `Success`     | `component`       | If the data has loaded, render this component                |
+| Name          | Type               | Description                                                  |
+| :------------ | :----------------- | :----------------------------------------------------------- |
+| `QUERY`       | `string\|function` | The query to execute                                         |
+| `beforeQuery` | `function`         | Lifecycle hook; prepares variables and options for the query |
+| `isEmpty`     | `function`         | Lifecycle hook; decides if Cell should render Empty          |
+| `afterQuery`  | `function`         | Lifecycle hook; sanitizes data returned from the query       |
+| `Loading`     | `component`        | If the request is in flight, render this component           |
+| `Empty`       | `component`        | If there's no data (`null` or `[]`), render this component   |
+| `Failure`     | `component`        | If something went wrong, render this component               |
+| `Success`     | `component`        | If the data has loaded, render this component                |
 
 Only `QUERY` and `Success` are required. If you don't export `Empty`, empty results are sent to `Success`, and if you don't export `Failure`, error is output to the console.
 


### PR DESCRIPTION
A one-character change to fix Markdown, and some whitespace to tidy it up. 

@reviewer - my vscode was making some whitespace changes on save which, I assume, are just based on my local formatting rules for markdown. I took a look at this repo's `prettier.config.js` and it doesn't seem to have Markdown-specific rules. Is there a way I can configure my environment to ensure I conform to Redwood's formatting preferences for `.md`? 