### PR TITLE
Cells: Example for failure cell with errorCode

### DIFF
--- a/docs/cells.md
+++ b/docs/cells.md
@@ -243,7 +243,7 @@ But, like `Loading`, Storybook is probably a better place to develop this.
 <!-- In development, we have it so that errors blanket the page.
 In production, failed cells won't break your app, they'll just be empty divs... -->
 
-In this example we use the `errorCode` to conditionally render the error heading title and we also use it for our translation string. 
+In this example, we use the `errorCode` to conditionally render the error heading title, and we also use it for our translation string.
 ```jsx
 export const Failure = ({ error, errorCode }: CellFailureProps) => {
   const { t } = useTranslation()

--- a/docs/cells.md
+++ b/docs/cells.md
@@ -243,6 +243,19 @@ But, like `Loading`, Storybook is probably a better place to develop this.
 <!-- In development, we have it so that errors blanket the page.
 In production, failed cells won't break your app, they'll just be empty divs... -->
 
+In this example we use the `errorCode` to conditionally render the error heading title and we also use it for our translation string. 
+```jsx
+export const Failure = ({ error, errorCode }: CellFailureProps) => {
+  const { t } = useTranslation()
+  return (
+    <div style={{ color: 'red' }}>
+      {errorCode === 'NO_CONFIG' ? <h1> NO_CONFIG </h1> : <h1> ERROR </h1>} 
+      Error: {error.message} - Code: {errorCode} - {t(`error.${errorCode}`)} 
+    </div>
+  )
+}
+```
+
 ### Success
 
 If everything went well, a Cell renders `Success`.

--- a/docs/cells.md
+++ b/docs/cells.md
@@ -249,7 +249,7 @@ export const Failure = ({ error, errorCode }: CellFailureProps) => {
   const { t } = useTranslation()
   return (
     <div style={{ color: 'red' }}>
-      {errorCode === 'NO_CONFIG' ? <h1> NO_CONFIG </h1> : <h1> ERROR </h1>} 
+      {errorCode === 'NO_CONFIG' ? <h1>NO_CONFIG</h1> : <h1>ERROR</h1>} 
       Error: {error.message} - Code: {errorCode} - {t(`error.${errorCode}`)} 
     </div>
   )


### PR DESCRIPTION
This explains the possibility of [ErrorCode](https://github.com/redwoodjs/redwood/pull/3721) with an example for failure cell. 
Fix #884 