### PR TITLE
Update docs link in index from subdomain `learn` to main

### DIFF
--- a/code/html/index.html
+++ b/code/html/index.html
@@ -19,7 +19,7 @@
       <ul class="flex flex-wrap mt-8 justify-center lg:justify-start lg:-ml-2">
         <li class="px-2 whitespace-no-wrap">
           <a
-            href="https://learn.redwoodjs.com/docs/tutorial/welcome-to-redwood"
+            href="https://redwoodjs.com/docs/tutorial/welcome-to-redwood"
             class="block mt-2 bg-red-700 text-white px-4 py-3 font-semibold rounded-lg hover:bg-red-600 transition duration-200"
             >Start the Tutorial</a
           >


### PR DESCRIPTION
Currently in the home page of redwood; the getting started button is still linking to the [learn subdomain](https://learn.redwoodjs.com/docs/tutorial/welcome-to-redwood/). I changed the link to point to the main website (removed learn in url)