### PR TITLE
Disable publishing search

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -11,7 +11,7 @@ const octokit = Octokit({
 })
 
 const { create: createDocs, buildNav } = require('./docutron.js')
-const { publish: publishSearch, getObjectIDs } = require('./search.js')
+// const { publish: publishSearch, getObjectIDs } = require('./search.js')
 const { run: buildNews } = require('./news.js')
 const { run: buildRoadmap } = require('./roadmap.js')
 
@@ -271,7 +271,7 @@ const setPageVersions = (version) => {
 }
 
 const main = async () => {
-  const objectIDs = await getObjectIDs()
+  // const objectIDs = await getObjectIDs()
   const version = await getLatestVersion()
 
   buildNews()
@@ -289,7 +289,7 @@ const main = async () => {
       const pages = createDocs(markdown, section.name, { ...file, version })
 
       navLinks += buildNav(pages, section.name, index).join('\n')
-      await publishSearch(markdown, section.name, { ...file, objectIDs })
+      // await publishSearch(markdown, section.name, { ...file, objectIDs })
       console.info('')
     })
     fs.writeFileSync(navPath, navLinks)


### PR DESCRIPTION
We no longer want redwoodjs.com to be publishing to the index since all the docs are in the main repo.