### PR TITLE
Add a Join the Community link to the Community drop down in the nav bar

### DIFF
--- a/web/src/layouts/MainLayout/Navigation/Navbar/Navbar.tsx
+++ b/web/src/layouts/MainLayout/Navigation/Navbar/Navbar.tsx
@@ -28,6 +28,23 @@ const MainLayoutNavbar = () => {
       name: 'Community',
       navigation: [
         {
+          name: 'Join the Community',
+          description:
+            'Learn about the people of RedwoodJS and opportunities to connect',
+          link: 'https://redwoodjs.com/community',
+          icon: () => (
+            <svg
+              width={36}
+              height={36}
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 32 32"
+              className="fill-current text-orange-600 transition duration-200"
+            >
+              <path d="M16.1357143,0 C7.37857143,0 0,7.03571429 0,15.7214286 C0,16 0.00714285714,32 0.00714285714,32 L16.1357143,31.9857143 C24.9,31.9857143 32,24.6785714 32,15.9928571 C32,7.30714286 24.9,0 16.1357143,0 Z M16,25.1428571 C14.6142857,25.1428571 13.2928571,24.8357143 12.1142857,24.2785714 L6.32142857,25.7142857 L7.95714286,20.3571429 C7.25714286,19.0642857 6.85714286,17.5785714 6.85714286,16 C6.85714286,10.95 10.95,6.85714286 16,6.85714286 C21.05,6.85714286 25.1428571,10.95 25.1428571,16 C25.1428571,21.05 21.05,25.1428571 16,25.1428571 Z"></path>
+            </svg>
+          ),
+        },
+        {
           name: 'Discord',
           description:
             'Watercooler, relationship building, quick discussion and help',


### PR DESCRIPTION
We made a few refinements to our Community messaging a couple months ago.  At that time, we talked about adding a 'Join the Community' link to the nav bar at the top of the web site.  This simple PR does just that.  

One Go-Do:  We should update the icon associated with the Join the Community link. 
 A Redwood logo would be great.  But, I'll need to recruit someone who's snappy at creating simple SVG images.  @KrisCoulson do you have such skills, or do you know someone that does?  