### PR TITLE
fix: redirect versions 1.0-1.2 of the docs to 1.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,12 @@ functions = "api/dist/functions"
   port = 8888
 
 [[redirects]]
+  from = "/docs/*"
+  to = "https://redwoodjs-docs.netlify.app/docs/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/docs/1.0/*"
   to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
   status = 200
@@ -31,12 +37,6 @@ functions = "api/dist/functions"
 [[redirects]]
   from = "/docs/1.2/*"
   to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
-  status = 200
-  force = true
-
-[[redirects]]
-  from = "/docs/*"
-  to = "https://redwoodjs-docs.netlify.app/docs/:splat"
   status = 200
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,19 +25,19 @@ functions = "api/dist/functions"
 [[redirects]]
   from = "/docs/1.0/*"
   to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
-  status = 200
+  status = 302
   force = true
 
 [[redirects]]
   from = "/docs/1.1/*"
   to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
-  status = 200
+  status = 302
   force = true
 
 [[redirects]]
   from = "/docs/1.2/*"
   to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
-  status = 200
+  status = 302
   force = true
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,12 +17,6 @@ functions = "api/dist/functions"
   port = 8888
 
 [[redirects]]
-  from = "/docs/*"
-  to = "https://redwoodjs-docs.netlify.app/docs/:splat"
-  status = 200
-  force = true
-
-[[redirects]]
   from = "/docs/1.0/*"
   to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
   status = 200
@@ -37,6 +31,12 @@ functions = "api/dist/functions"
 [[redirects]]
   from = "/docs/1.2/*"
   to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/docs/*"
+  to = "https://redwoodjs-docs.netlify.app/docs/:splat"
   status = 200
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,6 +23,24 @@ functions = "api/dist/functions"
   force = true
 
 [[redirects]]
+  from = "/docs/1.0/*"
+  to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/docs/1.1/*"
+  to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/docs/1.2/*"
+  to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/cookbook"
   to = "/docs/how-to/index"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,12 +17,6 @@ functions = "api/dist/functions"
   port = 8888
 
 [[redirects]]
-  from = "/docs/*"
-  to = "https://redwoodjs-docs.netlify.app/docs/:splat"
-  status = 200
-  force = true
-
-[[redirects]]
   from = "/docs/1.0/*"
   to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
   status = 302
@@ -38,6 +32,12 @@ functions = "api/dist/functions"
   from = "/docs/1.2/*"
   to = "https://redwoodjs-docs.netlify.app/docs/1.3/:splat"
   status = 302
+  force = true
+
+[[redirects]]
+  from = "/docs/*"
+  to = "https://redwoodjs-docs.netlify.app/docs/:splat"
+  status = 200
   force = true
 
 [[redirects]]


### PR DESCRIPTION
We had to unlist versions 1.0-1.2 of the docs due to a memory error during build (we have too many versions). Since they're unlisted and still get some views, we should redirect them to the latest 1.3 till we figure out a fix.