### PR TITLE
chore: remove redundant v1.x redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,24 +17,6 @@ functions = "api/dist/functions"
   port = 8888
 
 [[redirects]]
-  from = "/docs/1.0/*"
-  to = "/docs/1.3/:splat"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/docs/1.1/*"
-  to = "/docs/1.3/:splat"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/docs/1.2/*"
-  to = "/docs/1.3/:splat"
-  status = 302
-  force = true
-
-[[redirects]]
   from = "/docs/*"
   to = "https://redwoodjs-docs.netlify.app/docs/:splat"
   status = 200


### PR DESCRIPTION
It's better to add these to the redwoodjs/redwood repo; see https://github.com/redwoodjs/redwood/pull/7025. Waiting on https://github.com/redwoodjs/redwood/pull/7025.