### PR TITLE
Added a redirect for the Build Competition

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -130,6 +130,12 @@ functions = "api/dist/functions"
   force = true
 
 [[redirects]]
+  from = "/build"
+  to = "https://build.redwoodjs.com"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/200.html"
   status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -136,6 +136,12 @@ functions = "api/dist/functions"
   force = true
 
 [[redirects]]
+  from = "/build-competition"
+  to = "https://build.redwoodjs.com"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/200.html"
   status = 200


### PR DESCRIPTION
Going to redwoodjs.com/build should redirect to build.redwoodjs.com