### PR TITLE
fix "Core Team" link

### DIFF
--- a/web/src/components/Footer/Footer.tsx
+++ b/web/src/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ const navigation = {
     },
     {
       name: 'Core Team',
-      href: 'https://github.com/redwoodjs/redwood#core-team',
+      href: 'https://github.com/redwoodjs/redwood#contributors',
     },
     {
       name: 'All Contributors',

--- a/web/src/components/Footer/Footer.tsx
+++ b/web/src/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ const navigation = {
     },
     {
       name: 'Core Team',
-      href: 'https://github.com/redwoodjs/redwood#contributors',
+      href: 'https://github.com/redwoodjs/redwood#core-team-leadership',
     },
     {
       name: 'All Contributors',


### PR DESCRIPTION
The https://github.com/redwoodjs/redwood README.md file changed, and now there is no `Core Team` header or `#core-team` anchor. The `#contributors` anchor seems like the best one to point to.